### PR TITLE
Phase 0: Claude Code scaffolding, working agreement, issue templates

### DIFF
--- a/.claude/hooks/block-master-push.sh
+++ b/.claude/hooks/block-master-push.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Blocks any `git push` that would land on master/main.
+#
+# Enforces the working agreement in CLAUDE.md: Claude branches and opens a PR;
+# Adrian merges. A push to master deploys straight to production, so this is a
+# hook rather than a convention.
+#
+# Pushing a feature branch is allowed and expected.
+#
+# Wired up as a PreToolUse hook on Bash in .claude/settings.json.
+# Exit 0 = allow, exit 2 = block (stderr is shown to Claude).
+
+set -uo pipefail
+
+payload=$(cat)
+
+# Pull tool_input.command out of the hook payload. Node is always present here
+# (this is a Node project) and avoids depending on python3 / Xcode CLT.
+command=$(printf '%s' "$payload" | node -e '
+  let s = "";
+  process.stdin.on("data", d => s += d).on("end", () => {
+    try { process.stdout.write(JSON.parse(s)?.tool_input?.command ?? ""); }
+    catch { process.stdout.write(""); }
+  });
+' 2>/dev/null)
+
+# Not a push? Nothing to do.
+case "$command" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+# Case 1: master/main named explicitly.
+# Catches `git push origin master`, `git push -f origin HEAD:main`, etc.
+if printf '%s' "$command" | grep -Eq 'git push([^&|;]*)\b(master|main)\b'; then
+  echo "BLOCKED: that command pushes to master/main." >&2
+  echo "Push a feature branch and open a PR instead — see the working agreement in CLAUDE.md." >&2
+  exit 2
+fi
+
+# Case 2: a bare `git push` while sitting on master/main.
+branch=$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
+  echo "BLOCKED: current branch is '$branch', so this push would land on it." >&2
+  echo "Create a feature branch and open a PR instead — see the working agreement in CLAUDE.md." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(npm run build)",
+      "Bash(npm run serve)",
+      "Bash(npm test)",
+      "Bash(npm run test:*)",
+      "Bash(npm ci)",
+      "Bash(npm install)",
+      "Bash(npx eleventy:*)",
+      "Bash(npx mocha:*)",
+      "Bash(npx playwright install:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh label:*)",
+      "Bash(gh api repos/:owner/:repo/milestones:*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-master-push.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/new-gig/SKILL.md
+++ b/.claude/skills/new-gig/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: new-gig
+description: Scaffold a new gig (concert) post for adrianparker.com with correct front matter, dated filename, and the gig metadata fields. Use when Adrian asks to write up a concert, show, or gig he went to.
+---
+
+# New gig post
+
+A gig is a specialised post covering a concert. It lives in `content/posts/gigs/` and uses `gig-layout.njk`, which renders a metadata card plus optional setlist.fm, Spotify and Flickr links.
+
+There is a blank template at `content/posts/gigs/template.hmmm` (gitignored, so it never builds).
+
+## 1. Gather
+
+Required:
+
+- **Headline artist**
+- **Venue** and **city** (and **country** — usually `New Zealand`)
+- **Date of the gig** — this is the `date` field and drives the filename
+
+Optional — ask, but don't block on them:
+
+- **Support artists** — a list
+- **setlist.fm URL**
+- **Spotify playlist** — must be the `/embed/playlist/...` form, not a normal share link
+- **Flickr album URL** plus a **thumbnail URL** (`https://live.staticflickr.com/...`). Both are needed for the embed; one without the other won't render.
+
+## 2. Filename
+
+`content/posts/gigs/YYYYMMDD-Artist-Venue-City.md`, using the gig date.
+
+Examples in the repo: `20260523-Teen-Jesus-and-the-Jean-Teasers.md`, `20090218-Datsuns-Astoria-London.md`. The convention is loose after the date — artist alone is fine when it's unambiguous.
+
+## 3. Write the file
+
+```yaml
+---
+layout: gig-layout.njk
+title: 'Artist @ Venue, City'
+navtitle: 'YYYY Artist'
+summary: 'One line summary'
+metadesc: 'Concert review of Artist at Venue, City, D Month YYYY.'
+date: YYYY-MM-DD
+readingtime: 'N minutes'
+tags: ['gig']
+headlineArtist: 'Artist'
+supportArtists: ['Support One']
+venue: 'Venue'
+city: 'City'
+country: 'New Zealand'
+setlistfm: ''
+spotify: ''
+flickr: ''
+flickrThumbnail: ''
+---
+
+Opening paragraph.
+
+<!-- excerpt -->
+
+Rest of the review.
+```
+
+Conventions:
+
+- `title` — always `Artist @ Venue, City`.
+- `navtitle` — always `<year> <Artist>`, e.g. `2026 Teen Jesus`. Shorten long artist names; this appears in a 170px sidebar.
+- `metadesc` — always `Concert review of <Artist> at <Venue>, <City>, <D Month YYYY>.`
+- **Omit optional keys entirely rather than leaving them as empty strings.** The layout guards each with `{% if %}`, and an empty string is truthy enough to render a broken link.
+- `readingtime` — word count ÷ 200, rounded up. Most gig write-ups are `'1 minute'`.
+
+## 4. Verify
+
+```bash
+npm run build
+```
+
+Check `_site/posts/gigs/<Slug>/index.html` — confirm the metadata card renders, that any setlist.fm and Spotify links are present, and that the Flickr embed appears if you set both Flickr fields. Then confirm it shows on `_site/gigs/index.html` and the home page.
+
+## Notes
+
+- Don't commit to `master` — branch and open a PR, per CLAUDE.md.

--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: new-post
+description: Scaffold a new blog post for adrianparker.com with correct front matter, filename, and excerpt marker. Use when Adrian asks to start, draft, or create a new blog post (not a gig — use new-gig for concerts).
+---
+
+# New blog post
+
+Create a post in `content/posts/`. For a concert review, use the `new-gig` skill instead.
+
+## 1. Gather
+
+Ask only for what you don't already have:
+
+- **Title** — as displayed at the top of the article.
+- **Navtitle** — short form for the sidebar. Offer a shortened title as the default; many posts just reuse the title.
+- **Summary** — one line, shown on the index page and under the title.
+- **Metadesc** — a search-engine description. Distinct from the summary: written for someone deciding whether to click from a results page.
+- **Tags** — always `post`. Ask whether to add `popular` (surfaces it in the desktop sidebar) or a topic tag such as `diving`.
+
+## 2. Filename
+
+`content/posts/Kebab-Case-Title.md` — capitalised words joined by hyphens, matching the title. Examples in the repo: `Can-I-Touch-Your-Feet.md`, `Cognitive-Reframing.md`, `Tangalooma-Wrecks.md`.
+
+Strip apostrophes and punctuation. `Can I Touch Your Feet?` → `Can-I-Touch-Your-Feet.md`.
+
+This becomes the URL, so confirm it with Adrian before writing if the mapping isn't obvious.
+
+## 3. Write the file
+
+Keep this key order exactly:
+
+```yaml
+---
+layout: post-layout.njk
+title: 'Full Title As Displayed'
+navtitle: 'Short Title For Sidebar'
+summary: 'One line shown on the index and at the top of the article'
+metadesc: 'A brief description for search engines'
+date: YYYY-MM-DD
+readingtime: 'N minutes'
+tags: ['post']
+---
+
+## Opening heading
+
+First paragraph.
+
+<!-- excerpt -->
+
+Rest of the post.
+```
+
+- `date` — today, unless Adrian says otherwise.
+- `readingtime` — word count ÷ 200, rounded up. `'1 minute'` singular, `'N minutes'` plural. Recalculate this if you substantially edit the post later.
+- Body starts with `##`, not `#` — the layout already renders the title as the `<h1>`.
+- The `<!-- excerpt -->` marker sets what appears on index pages. Put it after the first paragraph or two — enough to draw someone in, not the whole opening section.
+
+## 4. Verify
+
+```bash
+npm run build
+```
+
+Confirm `_site/posts/<Slug>/index.html` exists and the post appears on `_site/index.html`. Then check it renders:
+
+```bash
+npm run serve
+```
+
+## Notes
+
+- Images use `{% image "img/photo.jpg", "Alt text" %}`. The alt text is **also rendered as the visible figcaption**, so write it to work as a caption.
+- Video uses `{% video "/video/clip.mp4" %}`.
+- Don't commit to `master` — branch and open a PR, per CLAUDE.md.

--- a/.claude/skills/update-baselines/SKILL.md
+++ b/.claude/skills/update-baselines/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: update-baselines
+description: Regenerate the visual regression baseline screenshots for adrianparker.com after a deliberate design change. Use when visual regression tests fail because of an intentional CSS or layout change, or when Adrian asks to update/refresh the baselines.
+---
+
+# Update visual baselines
+
+Baselines live in `tests/screenshots/` and are committed. Actuals land in `tests/screenshots-actual/` and are gitignored.
+
+## Before you regenerate — stop and check
+
+**A failing visual test is not automatically a stale baseline.** Decide which of these you're looking at:
+
+- **Deliberate design change** (you edited CSS or layout markup) → regenerating is correct.
+- **Change that should have been invisible** (dependency upgrade, template refactor, config change) → this is a **regression**. Investigate it. Do not regenerate.
+
+Look at the diff image in `tests/screenshots-actual/diff-*.png` and confirm the change is what you intended, over the whole page — not just in the area you were working on.
+
+Known trap: `tests/screenshots/home-page-mobile.png` is captured at exactly 768px, where the site's `max-width: 768px` media query collides with Pure.css's `min-width: 48em` grid tier. The current baseline captures that broken layout, so fixing the breakpoint will legitimately change it.
+
+## Regenerate
+
+```bash
+npm run build
+npx mocha tests/visual-regression.test.js --timeout 60000
+```
+
+Then copy actuals over baselines — **excluding the diff images**:
+
+```bash
+for f in tests/screenshots-actual/*.png; do
+  case "$(basename "$f")" in diff-*) continue ;; esac
+  cp "$f" tests/screenshots/
+done
+```
+
+Do **not** use `cp tests/screenshots-actual/*.png tests/screenshots/`. That is what `TESTING.md` currently says and it is wrong — it sweeps the `diff-*.png` files into the committed baseline directory. Several megabytes of them are already in there from previous refreshes.
+
+## Confirm and commit
+
+```bash
+git status --short tests/screenshots/
+```
+
+Every changed file should be a baseline you expected to change, and **no `diff-*.png` should appear**. If one does, delete it.
+
+Commit the baselines **separately from the change that caused them**:
+
+```bash
+git add tests/screenshots/
+git commit -m "Update visual baselines for <what changed>"
+```
+
+Two commits — the change, then the baselines — keeps the PR reviewable. A single commit mixing a CSS edit with eight binary PNGs hides the actual change.
+
+## Re-run to confirm green
+
+```bash
+npx mocha tests/visual-regression.test.js --timeout 60000
+```

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,25 @@
+name: Bug
+description: Something on the site is broken or wrong
+labels: []
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's wrong
+      description: What you see, and what you expected instead.
+    validations:
+      required: true
+
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: Page URL, or the file if you already know it.
+      placeholder: https://www.adrianparker.com/gigs/ — or static/index.css
+
+  - type: input
+    id: context
+    attributes:
+      label: Browser / viewport
+      description: Only if it matters — e.g. Edge on Windows, or narrow mobile.
+      placeholder: Edge, desktop 1400px

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,25 @@
+name: Task
+description: A change to make — feature, refactor, chore, or content
+labels: []
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What to do
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: The reason this is worth doing. Future-you and Claude both read this before starting.
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Done when
+      description: How to tell it's finished — including anything to verify by hand.
+      placeholder: |
+        - [ ] ...
+        - [ ] Tests pass, coverage not lowered

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ content/posts/*.hmmm
 content/posts/gigs/*.hmmm
 _site/
 tests/screenshots-actual/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo.
+
+---
+
+## Working agreement — read first
+
+**Never push to `master`.** All work goes on a branch and up as a pull request. Adrian reviews and merges manually.
+
+- Branch, commit, push the branch, open a PR. Stop there.
+- Merging is Adrian's call, always.
+- A push to `master` publishes to production immediately (see Deploy below) — that is why this rule exists.
+- This is enforced by a `PreToolUse` hook in `.claude/settings.json`, not just by convention. If the hook blocks you, that is working as intended — do not try to route around it.
+
+This rule is provisional and up for review around **February 2027** (tracked as a GitHub issue in the "Later" milestone).
+
+### Pull request rules
+
+- Every PR must have passing tests.
+- New JS needs new unit tests.
+- **No PR may lower the coverage percentage.** The floor lives in `.c8rc.json`; raise it as coverage grows, never lower it.
+
+---
+
+## What this site is
+
+Personal blog of Adrian Parker — [www.adrianparker.com](https://www.adrianparker.com). Static, built with **Eleventy**, hosted on **GitHub Pages**.
+
+Three content types:
+
+| Type | Lives in | URL |
+|---|---|---|
+| **Posts** | `content/posts/*.md` | `/posts/<Slug>/` |
+| **Gigs** | `content/posts/gigs/*.md` | `/posts/gigs/<Slug>/` |
+| **Apps** | `content/<AppName>/index.njk` | `/<AppName>/` |
+
+Gigs are a specialised post: a concert, usually with a setlist.fm link, sometimes a Spotify playlist and a Flickr album.
+
+---
+
+## Commands
+
+```bash
+npm run build          # eleventy build into _site/
+npm run serve          # local dev server, live reload, usually :8080
+npm test               # build + all mocha tests (includes visual regression, slow)
+npm run test:headless  # build + smoke tests only — this is what CI runs
+```
+
+---
+
+## Hard rules
+
+- **Never edit anything in `_site/`.** It is build output and is regenerated on every build. Edit the source instead.
+- **The stylesheet is `static/index.css`**, not `_site/index.css`. There is exactly one stylesheet for the whole blog.
+- `static/` is passthrough-copied to the site root, so `static/foo.css` is served at `/foo.css`.
+- `img/` is *not* passthrough-copied — those are source-resolution photos consumed by the `image` shortcode, which writes resized output to `_site/img/`.
+- The build input directory is `content/`.
+
+---
+
+## Deploy
+
+Merging to `master` triggers `.github/workflows/build.yml`, which builds, runs smoke tests, and publishes `_site/` to GitHub Pages via `peaceiris/actions-gh-pages`. Live within about two minutes.
+
+**There is no staging environment.** Whatever merges is what the public sees.
+
+---
+
+## Content conventions
+
+### Post
+
+File: `content/posts/Kebab-Case-Title.md`
+
+```yaml
+---
+layout: post-layout.njk
+title: 'Full Title As Displayed'
+navtitle: 'Short Title For Sidebar'
+summary: 'One line shown on the index and at the top of the article'
+metadesc: 'A brief description for search engines'
+date: 2026-07-19
+readingtime: '2 minutes'
+tags: ['post']
+---
+```
+
+Keep the key order above. Body starts with an `##` heading. Place a `<!-- excerpt -->` marker after the first paragraph or two — everything before it becomes the index-page excerpt.
+
+Optional extra tags alongside `post`: `popular` (surfaces it in the sidebar), plus free-form topic tags such as `diving`.
+
+### Gig
+
+File: `content/posts/gigs/YYYYMMDD-Artist-Venue-City.md`. There is a blank template at `content/posts/gigs/template.hmmm` (gitignored, so it never builds).
+
+```yaml
+---
+layout: gig-layout.njk
+title: 'Artist @ Venue, City'
+navtitle: '2026 Artist'
+summary: 'One line summary'
+metadesc: 'Concert review of Artist at Venue, City, D Month YYYY.'
+date: 2026-05-23
+readingtime: '1 minute'
+tags: ['gig']
+headlineArtist: 'Artist'
+supportArtists: ['Support One']
+venue: 'Venue'
+city: 'City'
+country: 'New Zealand'
+setlistfm: 'https://www.setlist.fm/...'
+spotify: 'https://open.spotify.com/embed/playlist/...'
+flickr: 'https://www.flickr.com/photos/adrianparker/albums/...'
+flickrThumbnail: 'https://live.staticflickr.com/...'
+---
+```
+
+`navtitle` convention for gigs is `'<year> <Artist>'`. Everything from `supportArtists` down is optional — the layout guards each with `{% if %}`.
+
+### Shortcodes
+
+```njk
+{% image "img/source-photo.jpg", "Alt text, also used as the visible figcaption" %}
+{% video "/video/clip.mp4" %}
+```
+
+`image` generates webp + jpeg at 400px and 800px. Note the alt text is *also* rendered as the `<figcaption>`, so write it to work as a visible caption.
+
+---
+
+## Testing
+
+Mocha + Chai, with Playwright + pixelmatch for visual regression.
+
+- `tests/smoke.test.js` — build validation, runs in CI.
+- `tests/visual-regression.test.js` — screenshots at 1200px (desktop) and mobile, compared against baselines in `tests/screenshots/`. Local only today.
+
+See `TESTING.md` for detail, and the `update-baselines` skill for the baseline refresh procedure.
+
+**On baselines:** a visual diff after a deliberate CSS change is expected. Regenerate baselines in a **separate commit** from the change itself so the diff stays reviewable. A visual diff after a change that should have been invisible (a dependency upgrade, a refactor) is a regression — investigate, do not paper over it by regenerating.
+
+---
+
+## Roadmap
+
+Work is tracked in GitHub Issues, organised into milestones by phase. Reference issues as `#N` in commit messages.
+
+The full roadmap and rationale lives in the plan file referenced from the Phase 0 PR.


### PR DESCRIPTION
Sets up the repo so Claude Code sessions can pick up a single issue without re-deriving context, and puts the new working agreement in place.

No user-visible change to the site. Build and all 16 smoke tests pass.

## What's here

**`CLAUDE.md`** — working agreement first: never push to `master`, branch and open a PR, Adrian merges. Then commands, hard rules (never edit `_site/`), deploy semantics, front matter templates for post/gig/app, testing policy, and baseline guidance.

**`.claude/hooks/block-master-push.sh`** — blocks any `git push` that would land on `master`/`main`, whether named explicitly (`git push origin master`, `git push -f origin HEAD:main`) or implied by the current branch. This is a hook rather than a `deny` permission because prefix matching can't distinguish a feature-branch push from a master push, and denying all pushes would break the PR workflow itself. Verified against six cases.

**`.claude/settings.json`** — permission allowlist for routine build/test/git/gh commands, plus the hook wiring.

**`.claude/skills/`** — `new-post`, `new-gig`, `update-baselines`.

**`.github/ISSUE_TEMPLATE/`** — Bug and Task, kept short for a solo repo.

## Note on the baseline skill

`TESTING.md` currently instructs `cp tests/screenshots-actual/*.png tests/screenshots/`, which sweeps `diff-*.png` into the committed baseline directory. **8.5MB of diff images are already in there** from previous refreshes. The skill documents the corrected glob; removing the committed files is #7.

## Backlog

36 issues seeded across 8 milestones. GitHub Issues had to be enabled on the repo — it was switched off.

Also worth knowing: `npm audit` reports 15 vulnerabilities (2 critical, 11 high). Both criticals arrive via Eleventy 2's bundled-but-unused template engines. All build-time only, nothing reaches visitors. #1 clears most of it.