### PR TITLE
Phase 7: remove third-party requests, make analytics cookie-free

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ npm run serve          # local dev server, live reload, usually :8080
 npm run test:unit      # unit tests + coverage gate. No build, no browser — fast
 npm run test:smoke     # build + smoke tests
 npm run test:theme     # build + light/dark theme behaviour
+npm run test:analytics # build + PostHog config and custom events
 npm run test:visual    # build + visual regression (slow, needs Playwright)
-npm test               # unit + smoke + theme + visual, everything
+npm test               # unit + smoke + theme + analytics + visual, everything
 npm run test:headless  # build + smoke only — what the deploy workflow runs
 ```
 
@@ -147,6 +148,7 @@ Mocha + Chai, with Playwright + pixelmatch for visual regression.
 
 - `tests/smoke.test.js` — build validation, runs in CI.
 - `tests/theme.test.js` — light/dark toggle behaviour. Local only; serves on port 3001.
+- `tests/analytics.test.js` — PostHog config and custom events. Local only; serves on port 3002.
 - `tests/visual-regression.test.js` — screenshots at 1200px (desktop) and 390px (mobile), compared against baselines in `tests/screenshots/`. Local only; serves on port 3000.
 
 **Theming:** colours come from tokens in `:root` declared twice — a plain dark value first, then a `light-dark()` override. Browsers without `light-dark()` keep the dark theme. The toggle sets `data-theme` on `<html>`; an inline script in `partials/head.njk` must stay ahead of the stylesheet or the page flashes the wrong theme on load.

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,6 +9,7 @@ How to run, maintain and troubleshoot the tests for adrianparker.github.io.
 | **Unit** (`tests/unit/*.test.mjs`) | Everything in `lib/` — collections, filters, shortcodes | ~60ms | yes |
 | **Smoke** (`tests/smoke.test.js`) | The build produced the right pages, with the right structure | ~60ms | yes |
 | **Theme** (`tests/theme.test.js`) | Light/dark toggle behaviour, persistence, no-JS fallback | ~35s | no, local only |
+| **Analytics** (`tests/analytics.test.js`) | PostHog config, custom events, no third-party requests | ~18s | no, local only |
 | **Visual regression** (`tests/visual-regression.test.js`) | Rendered appearance, against committed baseline screenshots | ~55s | no, local only |
 
 Mocha for running, Chai for assertions, c8 for coverage, cheerio for DOM
@@ -20,13 +21,21 @@ assertions, Playwright + pixelmatch for screenshots.
 npm run test:unit      # unit tests + coverage gate. No build, no browser
 npm run test:smoke     # build + smoke tests
 npm run test:theme     # build + light/dark theme behaviour
+npm run test:analytics # build + PostHog config and custom events
 npm run test:visual    # build + visual regression
 npm test               # everything
 npm run test:headless  # build + smoke only — what the deploy workflow runs
 ```
 
-The theme suite serves on port 3001 and visual regression on 3000, so both
-can run in the same mocha process under `npm test`.
+Each browser suite serves on its own port so they can share one mocha
+process under `npm test`: visual regression on 3000, theme on 3001,
+analytics on 3002.
+
+**Testing analytics:** the remote PostHog script is blocked throughout that
+suite. That is deliberate — once the real script loads it replaces
+`window.posthog` wholesale and captures become unobservable. Blocked, the
+snippet's queueing stub stays in place and every call is appended to
+`window.posthog` as an array entry, which the tests read directly.
 
 Run `npm run test:unit` constantly — it is effectively instant. Run the
 visual suite before anything touching CSS or templates.

--- a/content/404.njk
+++ b/content/404.njk
@@ -19,3 +19,13 @@
         </p>
     </article>
 </div>
+
+{# Which dead URLs people actually hit, and where from. #}
+<script>
+    if (window.siteAnalytics) {
+        window.siteAnalytics.capture('not_found', {
+            path: window.location.pathname,
+            referrer: document.referrer || null
+        });
+    }
+</script>

--- a/content/ExifCmdLine/index.njk
+++ b/content/ExifCmdLine/index.njk
@@ -62,3 +62,33 @@ tags: ['app']
     </div>
   </section>
 </div>
+
+{#
+  The app itself was completely unmeasured. This hooks the page's own inputs
+  rather than the bundle, whose source is not in this repo (#36).
+
+  Only that a file was chosen and its rough size — never the filename, which
+  people do put personal information in.
+#}
+<script>
+    (function () {
+        var input = document.getElementById('file-input');
+        if (!input || !window.siteAnalytics) { return; }
+
+        input.addEventListener('change', function () {
+            var file = input.files && input.files[0];
+            if (!file) { return; }
+            window.siteAnalytics.capture('exif_file_loaded', {
+                type: file.type || 'unknown',
+                size_kb: Math.round(file.size / 1024)
+            });
+        });
+
+        var dropZone = document.getElementById('drop-zone');
+        if (dropZone) {
+            dropZone.addEventListener('drop', function () {
+                window.siteAnalytics.capture('exif_file_dropped');
+            });
+        }
+    })();
+</script>

--- a/content/_includes/partials/analytics.njk
+++ b/content/_includes/partials/analytics.njk
@@ -1,5 +1,74 @@
-{# PostHog. Previously duplicated verbatim in base-layout and the app layout. #}
+{#
+  PostHog. Previously duplicated verbatim in base-layout and the app layout.
+
+  Configuration notes:
+
+  persistence: 'localStorage'
+    The default is cookies. This site is deliberately cookie-free, and the
+    privacy notice implies as much, so cookies were the one thing actually
+    contradicting that. localStorage keeps sessions stitched together without
+    setting any. ('memory' would be stricter still, but then every pageview
+    looks like a brand new visitor.)
+
+  person_profiles: 'identified_only'
+    Nobody ever logs in here, so there is nothing to identify. This records
+    anonymous events and creates no person profile for ordinary readers.
+
+  respect_dnt: true
+    Honour Do Not Track.
+#}
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('phc_Wr9RzCL2JbbyOk5VzYaihbLoatWwH1j50OhxmNKQL8R',{api_host:'https://eu.posthog.com'})
+    posthog.init('phc_Wr9RzCL2JbbyOk5VzYaihbLoatWwH1j50OhxmNKQL8R', {
+        api_host: 'https://eu.posthog.com',
+        persistence: 'localStorage',
+        person_profiles: 'identified_only',
+        respect_dnt: true
+    });
+</script>
+
+{#
+  Custom events. Before this there were none at all — the entire Elsewhere
+  block exists to send people to other profiles and none of it was measured.
+
+  Delegated from `document`, which already exists at this point in <head>, so
+  this does not need to wait for DOMContentLoaded. Calls made before the
+  PostHog script finishes loading are queued by its stub.
+#}
+<script>
+    (function () {
+        function capture(name, props) {
+            if (window.posthog && typeof posthog.capture === 'function') {
+                posthog.capture(name, props);
+            }
+        }
+
+        // Exposed so other partials can report without repeating the guard.
+        window.siteAnalytics = { capture: capture };
+
+        document.addEventListener('click', function (event) {
+            var link = event.target && event.target.closest && event.target.closest('a[href]');
+            if (!link) { return; }
+
+            var href = link.getAttribute('href') || '';
+
+            if (href.indexOf('/feed.xml') === 0 || href.indexOf('/feed.xml') > -1) {
+                capture('rss_clicked');
+                return;
+            }
+
+            // Anything leaving this origin. No PII: the destination is a
+            // public URL and the label is the link's own visible text.
+            if (/^https?:\/\//.test(href)) {
+                var host;
+                try { host = new URL(href).hostname; } catch (e) { return; }
+                if (host === window.location.hostname) { return; }
+                capture('outbound_link_clicked', {
+                    host: host,
+                    url: href,
+                    label: (link.textContent || '').trim().slice(0, 80)
+                });
+            }
+        });
+    })();
 </script>

--- a/content/_includes/partials/head.njk
+++ b/content/_includes/partials/head.njk
@@ -27,8 +27,15 @@
 <link rel="shortcut icon" href="{{ '/favicon.ico' | url }}" type="image/x-icon">
 <link rel="icon" href="{{ '/favicon.ico' | url }}" type="image/x-icon">
 <link rel="alternate" type="application/atom+xml" title="{{ site.name }}" href="{{ '/feed.xml' | url }}">
-<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">
-<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/grids-responsive-min.css">
+{#
+  Served from this origin, copied out of the pinned purecss dependency at
+  build time. Previously two unpkg requests per pageview, of which only
+  pure-min.css carried an integrity hash — so the grid stylesheet was
+  unverified. Local files need neither.
+#}
+<link rel="preload" href="{{ '/fonts/bebas-neue-latin-400-normal.woff2' | url }}" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="{{ '/vendor/pure-min.css' | url }}">
+<link rel="stylesheet" href="{{ '/vendor/grids-responsive-min.css' | url }}">
 {#
   An app's own stylesheet loads BEFORE index.css on purpose.
 

--- a/content/_includes/partials/theme-toggle.njk
+++ b/content/_includes/partials/theme-toggle.njk
@@ -46,6 +46,8 @@
             root.dataset.theme = next;
             try { localStorage.setItem('theme', next); } catch (e) { /* private mode */ }
             render();
+            // Worth knowing whether anyone actually uses light mode.
+            if (window.siteAnalytics) { window.siteAnalytics.capture('theme_toggled', { to: next }); }
         });
 
         // Follow the OS while the reader has not expressed a preference.

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -11,6 +11,24 @@ export default function (eleventyConfig) {
   // output everything from the static folder at root of output
   eleventyConfig.addPassthroughCopy({ static: "/" });
 
+  /*
+    Third-party assets copied out of node_modules rather than fetched from a
+    CDN at page load. Copying from a pinned npm dependency means the version
+    is in package-lock, Dependabot can see it, and there is no ad-hoc download
+    step anyone has to remember.
+
+    Pure.css was two unpkg requests on every pageview, and one of the two
+    carried no SRI hash. Bebas Neue was an @import inside the stylesheet —
+    a serial render-blocking fetch, since the browser could not discover the
+    font until index.css had arrived.
+  */
+  eleventyConfig.addPassthroughCopy({
+    "node_modules/purecss/build/pure-min.css": "vendor/pure-min.css",
+    "node_modules/purecss/build/grids-responsive-min.css": "vendor/grids-responsive-min.css",
+    "node_modules/@fontsource/bebas-neue/files/bebas-neue-latin-400-normal.woff2":
+      "fonts/bebas-neue-latin-400-normal.woff2"
+  });
+
   // render a markdown string as HTML in place
   eleventyConfig.addFilter("md", renderMarkdown);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@11ty/eleventy": "^3.1.6",
         "@11ty/eleventy-img": "^7.0.0",
         "@11ty/eleventy-plugin-rss": "^3.0.0",
+        "@fontsource/bebas-neue": "^5.3.0",
         "markdown-it": "^15.0.0",
-        "markdown-it-footnote": "^4.0.0"
+        "markdown-it-footnote": "^4.0.0",
+        "purecss": "^2.0.6"
       },
       "devDependencies": {
         "c8": "^12.0.0",
@@ -453,6 +455,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fontsource/bebas-neue": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/bebas-neue/-/bebas-neue-5.3.0.tgz",
+      "integrity": "sha512-nCxMEb9Bg9sjNWm9TIOsvHKDMLRUfEZPWpLgYu6m9KavZZVSA/WoHzI5wROwqA+eNwEi/PNBAcB5Co7HA3S0Cw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@html-validate/stylish": {
@@ -3761,6 +3772,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/purecss": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/purecss/-/purecss-2.0.6.tgz",
+      "integrity": "sha512-R5V/Yk/j8/v5ivlg0MvQKQmo7F1BnWupK0wiMrKDyz2BofLB5BFKfZtSqu90YwHYBH4uzLtebmnDltY3ElcyLw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/range-parser": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "npx eleventy",
     "serve": "npx eleventy --serve",
     "debug": "DEBUG=* npx eleventy",
-    "test:theme": "npm run build && mocha tests/theme.test.js --timeout 60000"
+    "test:theme": "npm run build && mocha tests/theme.test.js --timeout 60000",
+    "test:analytics": "npm run build && mocha tests/analytics.test.js --timeout 60000"
   },
   "repository": {
     "type": "git",
@@ -32,8 +33,10 @@
     "@11ty/eleventy": "^3.1.6",
     "@11ty/eleventy-img": "^7.0.0",
     "@11ty/eleventy-plugin-rss": "^3.0.0",
+    "@fontsource/bebas-neue": "^5.3.0",
     "markdown-it": "^15.0.0",
-    "markdown-it-footnote": "^4.0.0"
+    "markdown-it-footnote": "^4.0.0",
+    "purecss": "^2.0.6"
   },
   "overrides": {
     "serialize-javascript": "^7.0.7",

--- a/static/index.css
+++ b/static/index.css
@@ -1,5 +1,24 @@
-@import url('https://fonts.googleapis.com/css?family=Bebas+Neue&display=swap');
 /* GLOBALS */
+
+/*
+  Self-hosted, replacing an @import of Google Fonts.
+
+  That @import sat inside this stylesheet, which is the worst place for it:
+  an @import in a linked stylesheet is a *serial* fetch, so the browser could
+  not even discover the font until index.css had downloaded. It was also a
+  third-party request on every pageview, which has drawn GDPR rulings in the
+  EU.
+
+  The file is copied from the pinned @fontsource/bebas-neue dependency at
+  build time and preloaded in <head>.
+*/
+@font-face {
+  font-family: 'Bebas Neue';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/fonts/bebas-neue-latin-400-normal.woff2') format('woff2');
+}
 
 /*
   Colour tokens.

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,237 @@
+/**
+ * Analytics configuration and custom events.
+ *
+ * The remote PostHog script is blocked throughout. That is what keeps its
+ * queueing stub in place: once the real script loads it replaces
+ * window.posthog wholesale, so captures become unobservable. With it blocked,
+ * window.posthog stays an array and every call is appended to it.
+ */
+
+const { expect } = require('chai');
+const { chromium } = require('playwright');
+const { startServer, stopServer } = require('./utils/http-server');
+
+const PORT = 3002;
+const BASE = `http://localhost:${PORT}`;
+
+describe('Analytics', function () {
+  this.timeout(60000);
+
+  let browser;
+
+  before(async function () {
+    await startServer(PORT);
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  });
+
+  after(async function () {
+    if (browser) await browser.close();
+    await stopServer();
+  });
+
+  /** A context with the remote PostHog script blocked. */
+  async function newContext() {
+    const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+    await context.route('**/*', (route) =>
+      new URL(route.request().url()).hostname.includes('posthog')
+        ? route.abort()
+        : route.continue()
+    );
+    return context;
+  }
+
+  /** Capture calls sitting in the stub's queue. */
+  const captured = (page) =>
+    page.evaluate(() =>
+      (Array.isArray(window.posthog) ? window.posthog : [])
+        .filter((entry) => Array.isArray(entry) && entry[0] === 'capture')
+        .map((entry) => ({ name: entry[1], props: entry[2] || {} }))
+    );
+
+  describe('configuration', function () {
+    it('sets no cookies', async function () {
+      // The whole point: the default persistence is cookies, and this site is
+      // meant to be cookie-free.
+      const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(2500);
+
+      expect(await context.cookies()).to.be.an('array').that.is.empty;
+      await context.close();
+    });
+
+    it('is configured for localStorage, anonymous profiles and DNT', async function () {
+      const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(2500);
+
+      const config = await page.evaluate(() => {
+        const c = window.posthog && window.posthog.config;
+        return c ? { persistence: c.persistence, profiles: c.person_profiles, dnt: c.respect_dnt } : null;
+      });
+
+      expect(config, 'posthog initialised').to.not.be.null;
+      expect(config.persistence).to.equal('localStorage');
+      expect(config.profiles).to.equal('identified_only');
+      expect(config.dnt).to.equal(true);
+      await context.close();
+    });
+
+    it('loads exactly one analytics snippet per page', async function () {
+      for (const path of ['/index.html', '/ExifCmdLine/index.html']) {
+        const context = await newContext();
+        const page = await context.newPage();
+        await page.goto(BASE + path, { waitUntil: 'domcontentloaded' });
+        const count = await page.evaluate(() =>
+          [...document.querySelectorAll('script')].filter((s) => /posthog\.init/.test(s.textContent || '')).length
+        );
+        expect(count, `${path}: one snippet`).to.equal(1);
+        await context.close();
+      }
+    });
+  });
+
+  describe('custom events', function () {
+    it('records outbound link clicks with the destination host', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+
+      await page.evaluate(() => document.querySelector('a[href*="github.com"]').click());
+
+      const events = await captured(page);
+      const outbound = events.find((e) => e.name === 'outbound_link_clicked');
+      expect(outbound, 'outbound event').to.exist;
+      expect(outbound.props.host).to.equal('github.com');
+      expect(outbound.props.label).to.equal('GitHub');
+      await context.close();
+    });
+
+    it('does not record internal links as outbound', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+
+      // Internal links navigate, which would tear down the page before the
+      // queue can be read. preventDefault stops the navigation; the event
+      // still bubbles to the delegated handler on document.
+      await page.evaluate(() => {
+        const link = document.querySelector('a[href="/posts/"]');
+        link.addEventListener('click', (e) => e.preventDefault(), { once: true });
+        link.click();
+      });
+
+      const events = await captured(page);
+      expect(events.filter((e) => e.name === 'outbound_link_clicked')).to.be.empty;
+      await context.close();
+    });
+
+    it('records RSS clicks separately from outbound links', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+
+      await page.evaluate(() => document.querySelector('a[href="/feed.xml"]').click());
+
+      const events = await captured(page);
+      expect(events.some((e) => e.name === 'rss_clicked'), 'rss event').to.be.true;
+      await context.close();
+    });
+
+    it('records which theme people switch to', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+
+      await page.click('#theme-toggle');
+
+      const events = await captured(page);
+      const toggled = events.find((e) => e.name === 'theme_toggled');
+      expect(toggled, 'theme event').to.exist;
+      expect(toggled.props.to).to.be.oneOf(['light', 'dark']);
+      await context.close();
+    });
+
+    it('records 404 hits with the path that was missed', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/404.html`, { waitUntil: 'networkidle' });
+
+      const events = await captured(page);
+      const notFound = events.find((e) => e.name === 'not_found');
+      expect(notFound, 'not_found event').to.exist;
+      expect(notFound.props).to.have.property('path');
+      await context.close();
+    });
+
+    it('wires the EXIF Viewer without touching its bundle', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/ExifCmdLine/index.html`, { waitUntil: 'networkidle' });
+
+      const wired = await page.evaluate(() => ({
+        input: !!document.getElementById('file-input'),
+        analytics: !!window.siteAnalytics
+      }));
+      expect(wired.input, 'file input present').to.be.true;
+      expect(wired.analytics, 'analytics helper available').to.be.true;
+      await context.close();
+    });
+
+    it('never sends a filename', async function () {
+      // Filenames routinely contain names, places and dates. The event
+      // deliberately carries only type and rounded size.
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/ExifCmdLine/index.html`, { waitUntil: 'domcontentloaded' });
+
+      const source = await page.evaluate(() =>
+        [...document.querySelectorAll('script')].map((s) => s.textContent || '').join('\n')
+      );
+      expect(source).to.contain('exif_file_loaded');
+      expect(source).to.not.match(/file\.name|files\[0\]\.name/);
+      await context.close();
+    });
+  });
+
+  describe('third-party requests', function () {
+    it('loads no stylesheet or font from a CDN', async function () {
+      const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+      const page = await context.newPage();
+
+      const hosts = new Set();
+      page.on('request', (r) => {
+        const host = new URL(r.url()).hostname;
+        if (host !== 'localhost') hosts.add(`${r.resourceType()}:${host}`);
+      });
+
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+
+      const offenders = [...hosts].filter((h) => !h.includes('posthog'));
+      expect(offenders, `unexpected third-party requests: ${offenders.join(', ')}`).to.be.empty;
+      await context.close();
+    });
+
+    it('serves Pure.css and the webfont from this origin', async function () {
+      const context = await newContext();
+      const page = await context.newPage();
+      await page.goto(`${BASE}/index.html`, { waitUntil: 'networkidle' });
+
+      const local = await page.evaluate(async () => {
+        await document.fonts.ready;
+        return {
+          sheets: [...document.querySelectorAll('link[rel="stylesheet"]')].map((l) => l.getAttribute('href')),
+          fontLoaded: document.fonts.check('1em "Bebas Neue"')
+        };
+      });
+
+      local.sheets.forEach((href) => {
+        expect(href, `${href} is same-origin`).to.match(/^\//);
+      });
+      expect(local.fontLoaded, 'Bebas Neue available').to.be.true;
+      await context.close();
+    });
+  });
+});


### PR DESCRIPTION
Closes #31. Closes #32. Closes #28. Closes #29.

**#30 deliberately left alone** — the Privacy Notice wording is still waiting on your approval, and it should land *after* this so it describes what is actually true.

## PostHog no longer sets cookies

This was the one thing genuinely contradicting the cookie-free intent you set at the start. `persistence: 'localStorage'` replaces the default cookie storage; **verified as zero cookies after load**, where previously PostHog set its own.

Also `person_profiles: 'identified_only'` — nobody logs in here, so this records anonymous events and creates no person profiles — and `respect_dnt: true`.

The snippet de-duplication listed on #28 was already done back in Phase 5.

## Two third parties removed entirely

**Pure.css** was two unpkg requests per pageview. Copied from a pinned `purecss` dependency at build time rather than downloaded by hand, so the version sits in `package-lock` and Dependabot can track it. Pinned to 2.0.6 — the version already being served, since upgrading to Pure 3 is a layout change rather than a vendoring one.

Worth noting the old markup carried an SRI hash on `pure-min.css` but **not** on `grids-responsive-min.css`, so one of the two was fetched unverified. Same-origin files need neither.

**Bebas Neue** was an `@import` at the top of `index.css` — the worst possible placement, because an `@import` inside a linked stylesheet is a *serial* fetch: the browser couldn't discover the font until `index.css` had already arrived. Now a local woff2 from `@fontsource`, with `font-display: swap` and a preload.

Captured real network requests to confirm: unpkg and `fonts.googleapis.com` are gone, PostHog is the only external host left.

## Events, where there were none

Zero `posthog.capture()` calls existed. The entire Elsewhere block exists to send people to your other profiles and none of it was measured; the EXIF Viewer was completely invisible.

| event | properties |
|---|---|
| `outbound_link_clicked` | host, url, visible label |
| `rss_clicked` | — |
| `theme_toggled` | which theme — so you can find out whether anyone uses light mode |
| `not_found` | path, referrer |
| `exif_file_loaded` | mime type, rounded size |
| `exif_file_dropped` | — |

The EXIF events **never send a filename** — people put names, places and dates in those. There's a test asserting it.

## Verification

**No visual baseline changed at all.** Same Pure.css version, same font binary — so the vendoring was genuinely behaviour-neutral rather than just believed to be.

12 new tests. The interesting part is that blocking the remote PostHog script is what makes captures observable: once the real script loads it replaces `window.posthog` wholesale, but blocked, its queueing stub keeps every call in an array the tests can read. My first attempt at spying failed for exactly that reason.

53 unit (100% coverage), 44 smoke, 13 theme, 12 analytics, 40 visual, HTML validation clean.