### PR TITLE
Document decision: visual regression stays local-only

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -258,5 +258,8 @@ npx playwright install chromium
 ```
 
 **Screenshots differ on another machine** — font rendering differs across
-operating systems. Baselines are macOS-generated. This is why visual
-regression is not in CI; see #44.
+operating systems. Baselines are macOS-generated. Visual regression is
+deliberately local-only for this reason (decided in #44): a threshold loose
+enough to absorb cross-platform text rendering would be too loose to catch
+real layout regressions. Rely on running `npm run test:visual` locally
+before pushing anything visual.


### PR DESCRIPTION
## Summary
- Records the decision on #44: visual regression stays local-only (option 4). Cross-platform font rendering makes CI-viable baselines impractical without a diff threshold too loose to catch real regressions.
- Updates TESTING.md's troubleshooting note to reflect the decision instead of pointing at an open question.

Closes #44.

## Test plan
- [x] Docs-only change, no test suite impact.