### PR TITLE
Match IMAGE_SIZES to the current layout breakpoint

### DIFF
--- a/lib/shortcodes.mjs
+++ b/lib/shortcodes.mjs
@@ -6,8 +6,15 @@ export const IMAGE_WIDTHS = [400, 800];
 /** Formats the image shortcode generates. The last one is the <img> fallback. */
 export const IMAGE_FORMATS = ["webp", "jpeg"];
 
-/** Default `sizes` attribute, matching the site's single breakpoint. */
-export const IMAGE_SIZES = "(max-width: 768px) 400px, 800px";
+/**
+ * Default `sizes` attribute, describing the image's actual rendered width
+ * rather than a layout breakpoint pixel value. Below the site's single
+ * breakpoint (47.999em, matching static/index.css) the image spans nearly
+ * the full viewport; above it, it sits in the 75%-wide content column with
+ * 4% padding either side, which is roughly 68vw. Capped implicitly by the
+ * largest generated width in IMAGE_WIDTHS.
+ */
+export const IMAGE_SIZES = "(max-width: 47.999em) 100vw, 68vw";
 
 /** Where generated images are written. Overridable so tests need not write into _site. */
 export const IMAGE_OUTPUT_DIR = "_site/img/";

--- a/tests/unit/shortcodes.test.mjs
+++ b/tests/unit/shortcodes.test.mjs
@@ -9,7 +9,8 @@ import {
   videoShortcode,
   imageShortcode,
   IMAGE_WIDTHS,
-  IMAGE_FORMATS
+  IMAGE_FORMATS,
+  IMAGE_SIZES
 } from "../../lib/shortcodes.mjs";
 
 describe("shortcodes — stringifyAttributes", () => {
@@ -131,6 +132,22 @@ describe("shortcodes — imageShortcode", () => {
 
   it("passes the sizes attribute through to each source", () => {
     expect(html).to.contain('sizes="(max-width: 768px) 400px, 800px"');
+  });
+
+  it("defaults to IMAGE_SIZES, matching static/index.css's own breakpoint", async () => {
+    expect(IMAGE_SIZES).to.equal("(max-width: 47.999em) 100vw, 68vw");
+
+    const defaultSizesHtml = await imageShortcode(
+      sourceImage,
+      "A test caption",
+      undefined,
+      IMAGE_WIDTHS,
+      IMAGE_FORMATS,
+      undefined,
+      path.join(tmpDir, "out-default-sizes") + path.sep
+    );
+
+    expect(defaultSizesHtml).to.contain(`sizes="${IMAGE_SIZES}"`);
   });
 
   it("actually writes the resized files", () => {


### PR DESCRIPTION
## Summary
- `IMAGE_SIZES` still said `(max-width: 768px) 400px, 800px`, a stale value from before #18 moved the layout breakpoint to `47.999em`.
- Replaced with `(max-width: 47.999em) 100vw, 68vw`, which describes the image's actual rendered width instead of a hardcoded pixel switch: below the breakpoint the image spans ~100vw, above it it sits in the 75%-wide content column with 4% padding either side (`static/index.css` `.content`), which comes out to roughly 68vw.
- Purely a `sizes` hint for `srcset` selection — no layout impact, confirmed by an unchanged visual regression suite.

Closes #55.

## Test plan
- [x] `npm run test:unit` — added a test asserting the default `sizes` attribute matches `IMAGE_SIZES` and its exact value
- [x] `npm run test:smoke`
- [x] `npm run test:visual` (unchanged)
- [x] Spot-checked generated markup: `sizes="(max-width: 47.999em) 100vw, 68vw"` in built pages