### PR TITLE
Update privacy notice wording (autocapture, no cookies)

### DIFF
--- a/content/_includes/partials/site-footer.njk
+++ b/content/_includes/partials/site-footer.njk
@@ -6,8 +6,6 @@
 
   Same site.externals data as the sidebar, different presentation.
 
-  The privacy notice wording is deliberately untouched — proposed changes are
-  captured in #30 for approval rather than edited here.
 #}
 <footer class="site-footer">
 
@@ -19,7 +17,7 @@
     <div class="privacy-notice">
         <h2 class="privacy-notice-heading">Privacy Notice</h2>
         <p class="privacy-notice-text">
-            This site uses PostHog for analytics. No personally identifiable information is collected.
+            This site uses PostHog for analytics, which records clicks and pageviews automatically. No cookies — usage data and theme preference live in local storage. No personal information is collected.
         </p>
     </div>
 


### PR DESCRIPTION
## Summary
- Updates the footer privacy notice per the wording Adrian approved in #30
- Discloses PostHog autocapture (clicks/pageviews recorded automatically)
- States no cookies are set, and that usage data + theme preference live in local storage
- Keeps the existing no-PII statement

## Not in scope
`/ExifCmdLine/` still doesn't show this notice despite loading PostHog — left as a follow-up per #30, not addressed here.

## Test plan
- [x] `npm run build` succeeds and the new text appears in the built footer
- [x] `npm run test:unit` passes, coverage 100%
- [x] `npm run test:smoke` passes

Closes #30.