### PR TITLE
Deploy via actions/deploy-pages instead of legacy branch build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,13 @@ on:
 
 # Never let two deploys race; the later push should win.
 concurrency:
-  group: pages-deploy
+  group: pages
   cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -41,9 +46,26 @@ jobs:
       # Visual regression deliberately does not run here — baselines are
       # macOS-generated and Ubuntu rasterises text differently. See #44.
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      # actions/deploy-pages needs the custom domain baked into the
+      # artifact itself — unlike peaceiris/actions-gh-pages there is no
+      # `cname` input to do this for us.
+      - name: Add custom domain
+        run: cp CNAME _site/CNAME
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          publish_dir: ./_site
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          cname: www.adrianparker.com
+          path: ./_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- The last several deploys got stuck in GitHub's legacy Pages builder (`build_type: legacy`, source: `gh-pages` branch) — builds sat "building" for ~10 minutes then errored or got cancelled, unrelated to any content change (confirmed via `gh api repos/.../pages/builds`)
- Replaces `peaceiris/actions-gh-pages` with the supported `actions/upload-pages-artifact` + `actions/deploy-pages` flow, retiring the legacy builder
- Adds a step to copy the root `CNAME` file into `_site/` before upload, since `deploy-pages` has no `cname` input equivalent to what `peaceiris` provided
- Splits into `build` and `deploy` jobs per GitHub's standard Pages Actions pattern, with `pages: write` / `id-token: write` permissions

## Manual step required after merge
**Settings → Pages → Build and deployment → Source** needs to be switched from "Deploy from a branch" to **"GitHub Actions"** for this workflow to actually take effect. Until that's flipped, the legacy builder will keep running (and keep failing) alongside this.

## Test plan
- [x] `npm run build` and `npm run test:unit` pass (no logic in `lib/` touched, coverage unaffected)
- [x] Locally verified `cp CNAME _site/CNAME` produces the expected file
- [ ] After merge + flipping the Pages source setting, confirm a push to `master` deploys successfully and `www.adrianparker.com` serves the latest content