### PR TITLE
Convert test suite from CommonJS to ESM

### DIFF
--- a/.claude/skills/update-baselines/SKILL.md
+++ b/.claude/skills/update-baselines/SKILL.md
@@ -67,6 +67,6 @@ something remote is affecting that page; find it.
 
 ## Adding a page
 
-Add one line to `testPages` in `tests/config.js`. The suite crosses it with
+Add one line to `testPages` in `tests/config.mjs`. The suite crosses it with
 every viewport automatically. The first run fails with "No baseline" — that is
 correct, generate and commit them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,6 @@ visual suite before anything touching CSS or templates.
 - `static/` is passthrough-copied to the site root, so `static/foo.css` is served at `/foo.css`.
 - `img/` is *not* passthrough-copied — those are source-resolution photos consumed by the `image` shortcode, which writes resized output to `_site/img/`.
 - The build input directory is `content/`, set via `dir.input` in the config.
-- **The Eleventy config is `eleventy.config.mjs` and is ESM** (`import`/`export`). The rest of the project — including the whole test suite — is CommonJS (`require`). `package.json` has no `"type": "module"`, which is what keeps those two coexisting. If you add a new `.js` file it will be CommonJS; use `.mjs` if you need ESM.
 - Node 22+ is required (`@11ty/eleventy-img` v7). See `.nvmrc`.
 
 ---
@@ -146,10 +145,10 @@ flickrThumbnail: 'https://live.staticflickr.com/...'
 
 Mocha + Chai, with Playwright + pixelmatch for visual regression.
 
-- `tests/smoke.test.js` — build validation, runs in CI.
-- `tests/theme.test.js` — light/dark toggle behaviour. Local only; serves on port 3001.
-- `tests/analytics.test.js` — PostHog config and custom events. Local only; serves on port 3002.
-- `tests/visual-regression.test.js` — screenshots at 1200px (desktop) and 390px (mobile), compared against baselines in `tests/screenshots/`. Local only; serves on port 3000.
+- `tests/smoke.test.mjs` — build validation, runs in CI.
+- `tests/theme.test.mjs` — light/dark toggle behaviour. Local only; serves on port 3001.
+- `tests/analytics.test.mjs` — PostHog config and custom events. Local only; serves on port 3002.
+- `tests/visual-regression.test.mjs` — screenshots at 1200px (desktop) and 390px (mobile), compared against baselines in `tests/screenshots/`. Local only; serves on port 3000.
 
 **Theming:** colours come from tokens in `:root` declared twice — a plain dark value first, then a `light-dark()` override. Browsers without `light-dark()` keep the dark theme. The toggle sets `data-theme` on `<html>`; an inline script in `partials/head.njk` must stay ahead of the stylesheet or the page flashes the wrong theme on load.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,10 +7,10 @@ How to run, maintain and troubleshoot the tests for adrianparker.github.io.
 | Suite | What it covers | Speed | Runs in CI |
 |---|---|---|---|
 | **Unit** (`tests/unit/*.test.mjs`) | Everything in `lib/` — collections, filters, shortcodes | ~60ms | yes |
-| **Smoke** (`tests/smoke.test.js`) | The build produced the right pages, with the right structure | ~60ms | yes |
-| **Theme** (`tests/theme.test.js`) | Light/dark toggle behaviour, persistence, no-JS fallback | ~35s | no, local only |
-| **Analytics** (`tests/analytics.test.js`) | PostHog config, custom events, no third-party requests | ~18s | no, local only |
-| **Visual regression** (`tests/visual-regression.test.js`) | Rendered appearance, against committed baseline screenshots | ~55s | no, local only |
+| **Smoke** (`tests/smoke.test.mjs`) | The build produced the right pages, with the right structure | ~60ms | yes |
+| **Theme** (`tests/theme.test.mjs`) | Light/dark toggle behaviour, persistence, no-JS fallback | ~35s | no, local only |
+| **Analytics** (`tests/analytics.test.mjs`) | PostHog config, custom events, no third-party requests | ~18s | no, local only |
+| **Visual regression** (`tests/visual-regression.test.mjs`) | Rendered appearance, against committed baseline screenshots | ~55s | no, local only |
 
 Mocha for running, Chai for assertions, c8 for coverage, cheerio for DOM
 assertions, Playwright + pixelmatch for screenshots.
@@ -69,7 +69,7 @@ those.
 
 ### How it works
 
-Pages are listed once in `tests/config.js` under `testPages`, and the suite
+Pages are listed once in `tests/config.mjs` under `testPages`, and the suite
 crosses them with every viewport in `viewports`. Adding a page means adding
 one line; you do not touch the test file.
 
@@ -85,7 +85,7 @@ Every page is captured in **dark**. Only the pages in `lightThemePages`
 That is deliberate rather than lazy. Layout regressions look identical in
 either theme, so a second full set would mostly duplicate the first; colour
 bugs that survive a theme switch — a hardcoded value, an icon that cannot be
-recoloured — are asserted directly in `tests/theme.test.js`. And 16 baselines
+recoloured — are asserted directly in `tests/theme.test.mjs`. And 16 baselines
 were already 11MB, with every refresh adding that again to git history.
 
 The two chosen pages between them cover entry listings, the gig metadata card
@@ -95,7 +95,7 @@ Baseline filenames carry the theme: `home-page-desktop-dark.png`.
 
 ### Thresholds
 
-`maxDiffRatio` in `tests/config.js` is **0.1%** of pixels, uniformly.
+`maxDiffRatio` in `tests/config.mjs` is **0.1%** of pixels, uniformly.
 
 Previously most pages allowed 5% while two video-post assertions demanded
 exactly 0. 5% is loose enough that an entire sidebar column could change
@@ -104,7 +104,7 @@ without failing.
 ### Determinism
 
 Four things make the capture repeatable, all in
-`tests/utils/screenshot-utils.js`. Each was added in response to a specific
+`tests/utils/screenshot-utils.mjs`. Each was added in response to a specific
 observed flake, not speculatively:
 
 1. **Lazy images are forced eager, then awaited via `decode()`.** The image
@@ -240,7 +240,7 @@ so they describe what is actually wrong rather than which substring vanished.
 ## Adding tests
 
 **A new page under visual regression:** add one line to `testPages` in
-`tests/config.js`, run the suite (it will fail with "No baseline"), then
+`tests/config.mjs`, run the suite (it will fail with "No baseline"), then
 generate and commit baselines.
 
 **New code in `lib/`:** it needs unit tests in `tests/unit/`, and the coverage

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Personal website of Adrian Parker.",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:unit && npm run build && mocha tests/*.test.js --timeout 60000",
+    "test": "npm run test:unit && npm run build && mocha tests/*.test.mjs --timeout 60000",
     "test:unit": "c8 mocha 'tests/unit/**/*.test.mjs'",
-    "test:smoke": "npm run build && mocha 'tests/smoke.test.js' --reporter spec",
-    "test:visual": "npm run build && mocha 'tests/visual-regression.test.js' --timeout 60000",
-    "test:headless": "npm run build && mocha 'tests/smoke.test.js' --reporter spec",
+    "test:smoke": "npm run build && mocha 'tests/smoke.test.mjs' --reporter spec",
+    "test:visual": "npm run build && mocha 'tests/visual-regression.test.mjs' --timeout 60000",
+    "test:headless": "npm run build && mocha 'tests/smoke.test.mjs' --reporter spec",
     "lint:html": "html-validate $(find _site -name '*.html' -not -path '*/dist/*')",
     "build": "npx eleventy",
     "serve": "npx eleventy --serve",
     "debug": "DEBUG=* npx eleventy",
-    "test:theme": "npm run build && mocha tests/theme.test.js --timeout 60000",
-    "test:analytics": "npm run build && mocha tests/analytics.test.js --timeout 60000"
+    "test:theme": "npm run build && mocha tests/theme.test.mjs --timeout 60000",
+    "test:analytics": "npm run build && mocha tests/analytics.test.mjs --timeout 60000"
   },
   "repository": {
     "type": "git",

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -7,9 +7,9 @@
  * window.posthog stays an array and every call is appended to it.
  */
 
-const { expect } = require('chai');
-const { chromium } = require('playwright');
-const { startServer, stopServer } = require('./utils/http-server');
+import { expect } from 'chai';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
 
 const PORT = 3002;
 const BASE = `http://localhost:${PORT}`;

--- a/tests/config.mjs
+++ b/tests/config.mjs
@@ -6,7 +6,7 @@
 // straight off disk.
 const baseUrl = process.env.TEST_BASE_URL || `file://${process.cwd()}/_site`;
 
-module.exports = {
+export default {
   baseUrl,
 
   viewports: {
@@ -51,7 +51,7 @@ module.exports = {
    *  - layout regressions show up identically in either theme, so a second
    *    full set would mostly duplicate the first
    *  - colour bugs that survive a theme switch (a hardcoded value, an
-   *    unmaskable icon) are asserted directly in tests/theme.test.js
+   *    unmaskable icon) are asserted directly in tests/theme.test.mjs
    *  - 16 baselines are already 11MB, and every refresh adds that again to
    *    git history
    *

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -8,10 +8,10 @@
  * if the class was in the stylesheet but missing from the page.
  */
 
-const { expect } = require('chai');
-const fs = require('fs');
-const path = require('path');
-const cheerio = require('cheerio');
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import * as cheerio from 'cheerio';
 
 const SITE = path.join(process.cwd(), '_site');
 

--- a/tests/theme.test.mjs
+++ b/tests/theme.test.mjs
@@ -6,11 +6,11 @@
  * tested. These cover it instead.
  */
 
-const { expect } = require('chai');
-const fs = require('fs');
-const path = require('path');
-const { chromium } = require('playwright');
-const { startServer, stopServer } = require('./utils/http-server');
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
 
 // Its own port: the visual suite holds 3000 and both run under `npm test`.
 const PORT = 3001;

--- a/tests/utils/http-server.mjs
+++ b/tests/utils/http-server.mjs
@@ -3,9 +3,9 @@
  * This ensures CSS and other assets load correctly in visual regression tests.
  */
 
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
 
 let server = null;
 
@@ -14,7 +14,7 @@ let server = null;
  * @param {number} port - Port to listen on (default 3000)
  * @returns {Promise<number>} The port the server is listening on
  */
-function startServer(port = 3000) {
+export function startServer(port = 3000) {
   return new Promise((resolve, reject) => {
     const siteDir = path.join(process.cwd(), '_site');
 
@@ -82,7 +82,7 @@ function startServer(port = 3000) {
  * Stop the HTTP server
  * @returns {Promise<void>}
  */
-function stopServer() {
+export function stopServer() {
   return new Promise((resolve, reject) => {
     if (!server) {
       resolve();
@@ -99,8 +99,3 @@ function stopServer() {
     });
   });
 }
-
-module.exports = {
-  startServer,
-  stopServer
-};

--- a/tests/utils/screenshot-utils.mjs
+++ b/tests/utils/screenshot-utils.mjs
@@ -2,22 +2,16 @@
  * Utility functions for screenshot-based visual regression testing.
  */
 
-const fs = require('fs');
-const { chromium } = require('playwright');
-// pixelmatch 5 sets module.exports to the function directly; 6+ is ESM, so
-// require() hands back a namespace object with the function on .default.
-// Node 22 can require() either, but the shapes differ — accept both so the
-// suite does not break on whichever version is installed.
-const pixelmatchModule = require('pixelmatch');
-const pixelmatch =
-  typeof pixelmatchModule === 'function' ? pixelmatchModule : pixelmatchModule.default;
-const PNG = require('pngjs').PNG;
-const config = require('../config');
+import fs from 'fs';
+import { chromium } from 'playwright';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+import config from '../config.mjs';
 
 /**
  * Screenshots a page at a given viewport.
  */
-async function takeScreenshot(pageUrl, viewport, screenshotPath, colorScheme = 'dark') {
+export async function takeScreenshot(pageUrl, viewport, screenshotPath, colorScheme = 'dark') {
   let browser;
   try {
     browser = await chromium.launch(config.browserOptions);
@@ -114,7 +108,7 @@ function readPng(filePath) {
  * normal (failing) result; previously pixelmatch threw "Image sizes do not
  * match" as an uncaught error, which surfaced as an unreadable stack trace.
  */
-function compareScreenshots(baselinePath, actualPath, diffPath) {
+export function compareScreenshots(baselinePath, actualPath, diffPath) {
   const baseline = readPng(baselinePath);
   const actual = readPng(actualPath);
 
@@ -156,7 +150,7 @@ function compareScreenshots(baselinePath, actualPath, diffPath) {
  * Builds the assertion message for a failed comparison. Kept next to the
  * comparison so the two stay consistent.
  */
-function describeFailure(name, result) {
+export function describeFailure(name, result) {
   if (result.sizeMismatch) {
     return (
       `${name}: image dimensions differ — baseline ${result.baselineSize}, ` +
@@ -172,20 +166,12 @@ function describeFailure(name, result) {
   );
 }
 
-function getScreenshotFilename(testName, viewportName, theme = 'dark') {
+export function getScreenshotFilename(testName, viewportName, theme = 'dark') {
   return `${testName}-${viewportName}-${theme}.png`;
 }
 
-function ensureScreenshotDir(dirPath) {
+export function ensureScreenshotDir(dirPath) {
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true });
   }
 }
-
-module.exports = {
-  takeScreenshot,
-  compareScreenshots,
-  describeFailure,
-  getScreenshotFilename,
-  ensureScreenshotDir
-};

--- a/tests/visual-regression.test.mjs
+++ b/tests/visual-regression.test.mjs
@@ -11,21 +11,25 @@
  * allowed a 5% difference.
  */
 
-// Must be set before anything reads config.
+// Must be set before anything reads config. Static imports are hoisted and
+// evaluated before any other top-level code in an ES module, regardless of
+// where they're written, so anything reaching config.mjs is imported
+// dynamically below, after this line actually runs.
 process.env.TEST_BASE_URL = 'http://localhost:3000';
 
-const { expect } = require('chai');
-const fs = require('fs');
-const path = require('path');
-const { startServer, stopServer } = require('./utils/http-server');
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { startServer, stopServer } from './utils/http-server.mjs';
+
 const {
   takeScreenshot,
   compareScreenshots,
   describeFailure,
   getScreenshotFilename,
   ensureScreenshotDir
-} = require('./utils/screenshot-utils.js');
-const config = require('./config');
+} = await import('./utils/screenshot-utils.mjs');
+const { default: config } = await import('./config.mjs');
 
 describe('Visual Regression Tests - Responsive Design', function () {
   this.timeout(60000);
@@ -43,7 +47,7 @@ describe('Visual Regression Tests - Responsive Design', function () {
   Object.entries(config.testPages).forEach(([pageName, pagePath]) => {
     config.themes.forEach((theme) => {
       // Dark covers every page; light covers a representative subset. See the
-      // reasoning on `lightThemePages` in tests/config.js.
+      // reasoning on `lightThemePages` in tests/config.mjs.
       if (theme === 'light' && !config.lightThemePages.includes(pageName)) return;
 
       Object.values(config.viewports).forEach((viewport) => {


### PR DESCRIPTION
## Summary
- Converts `tests/config.js`, `tests/utils/*.js`, and the four `.test.js` files to `.mjs`, swapping `require()`/`module.exports` for `import`/`export`.
- Updates the npm script globs in `package.json` that referenced the old `.js` filenames.
- Updates file references in `CLAUDE.md`, `TESTING.md`, and the `update-baselines` skill.
- Removes `CLAUDE.md`'s now-outdated note about the test suite being CommonJS while `eleventy.config.mjs` is ESM.

## Bug found and fixed along the way
`visual-regression.test.mjs` set `process.env.TEST_BASE_URL` textually before its imports, matching the original CommonJS file's intent — but ES module static imports are hoisted and evaluated before any other top-level code, regardless of source order. That meant `config.mjs` was reading the env var before it was ever set, silently falling back to its `file://` default. Every screenshot was captured against the filesystem instead of the local server, so every page's absolute-path CSS/asset links 404'd and every capture rendered completely unstyled — a systemic, page-agnostic dimension mismatch across all 40 visual regression assertions.

Fixed by switching the imports that reach `config.mjs` (`screenshot-utils.mjs` and `config.mjs` itself) to dynamic `import()`, so they run after the environment variable assignment actually executes.

## Test plan
- [x] `npm run test:unit` — 54 tests, 100% coverage on all four metrics
- [x] `npm test` — 109 tests (smoke, gigs, structure/a11y, apps, discoverability, internal links, theme, analytics, visual regression), all passing
- [x] Confirmed the visual regression pass count and screenshots match pre-conversion behaviour exactly (same 40/40, no baseline changes needed)

Resolves #48.