### PR TITLE
Give the light-mode nav a distinct colour for the current post

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -54,7 +54,7 @@
   lines instead.
 
   Contrast on the light background (worst case, against --color-bg-bottom):
-  text 11.9:1, accent 6.7:1, muted 5.3:1.
+  text 11.9:1, accent 6.7:1, muted 5.3:1, nav-current 5.2:1.
 */
 :root {
   color-scheme: light dark;
@@ -74,6 +74,16 @@
   /* Muted text and hover states. */
   --color-muted: #666666;
   --color-muted: light-dark(#55606b, #666666);
+
+  /* Marks the currently-viewed post/gig/app in the sidebar nav. Same value
+     as --color-muted in dark mode, which already reads as a clear third
+     tone next to --color-text and --color-accent. In light mode
+     --color-muted sits too close in hue and lightness to --color-text to
+     register as a different colour at all, so this uses a distinct green
+     instead — cool like the rest of the light palette, but a clean hue
+     break from the navy/blue everything else uses. See #65. */
+  --color-nav-current: #666666;
+  --color-nav-current: light-dark(#2f6b4f, #666666);
 
   /*
     These three were all --subheading-color, which was doing four jobs at
@@ -482,7 +492,7 @@ html.js .theme-toggle {
 }
 
 .pure-menu-selected>.pure-menu-link, .pure-menu-selected>.pure-menu-link:visited {
-  color: var(--color-muted);
+  color: var(--color-nav-current);
 }
 
 /* AdrianParker.com styling */


### PR DESCRIPTION
## Summary
- Adds a new token, `--color-nav-current`, for the sidebar's "currently viewed" post/gig/app indicator (`.pure-menu-selected>.pure-menu-link`).
- Dark mode value is unchanged (`#666666`, same as `--color-muted` today) — dark mode is pixel-identical.
- Light mode value is a distinct forest green (`#2f6b4f`, 5.2:1 contrast against the light background), chosen from four color options reviewed and discussed with Adrian ahead of this change.

## Why
`--color-muted` (`#55606b`) sits too close in hue and lightness to `--color-text` (`#1e2a3a`) in light mode to read as a different colour — the "you are here" cue in the nav effectively disappears. Dark mode doesn't have this problem because `--color-muted` (`#666666`) is a clearly separate tone from both the light-grey nav text and the orange accent. Forest green fixes the light-mode case by breaking hue rather than just adjusting lightness, while staying in the same cool family as the rest of the light palette and not competing with the blue accent used for headings/links.

## Test plan
- [x] `npm run test:unit` — 54 tests, 100% coverage
- [x] `npm test` — 109 tests, all passing, **zero baseline changes** (the only light-themed visual regression baselines — home-page and a 2009 gig post — don't have a currently-selected nav item active, so this change doesn't touch any committed screenshot)
- [x] Manually verified in browser: light mode now shows the current post in forest green; dark mode is visually unchanged

Fixes #65.