### PR TITLE
Fix app nav title hover and chevron sizing

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -844,6 +844,16 @@ figure {
   white-space: nowrap;
 }
 
+.app-nav-home:hover,
+.app-nav-home:focus {
+  text-decoration: underline;
+}
+
+.app-nav-home:hover .site-name,
+.app-nav-home:focus .site-name {
+  color: var(--color-muted);
+}
+
 .app-nav-mugshot {
   flex: 0 0 auto;
   width: 34px;
@@ -946,9 +956,13 @@ html.js .app-nav-collapse {
   color: var(--color-accent);
 }
 
+.app-nav-collapse:hover .app-nav-chevron {
+  color: var(--color-accent);
+}
+
 .app-nav-chevron::before {
   content: "\2039";
-  font-size: 1.4em;
+  font-size: 2.8em;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- App nav site title now underlines and switches to the muted colour on hover, matching the rest of the site (previously `.site-name`'s explicit accent colour overrode the inherited hover state)
- Collapse chevron doubled in size and now turns orange on hover, matching the "Collapse" label text

## Test plan
- [x] Verified both hover states visually in the browser on the Gig History app page (desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)