### PR TITLE
Generate the Gig Tracker's data from an in-repo markdown file at build time

### DIFF
--- a/content/GigTracker/README.md
+++ b/content/GigTracker/README.md
@@ -1,29 +1,62 @@
 # Gig Tracker — source file contract
 
-`gig-history.html` and `gig-history.css` in this directory are **written by the
-Gig Tracker agent, not by hand**. adrianparker.com rebuilds the page at
-`/GigTracker/` from them on every build, so whatever the two files say at build
-time is what gets published. Overwrite them freely; nothing here edits them
-back.
+Three files in this directory feed the Gig Tracker page, each with a
+different owner:
+
+- **`gig-history.md`** — the gig data, one row per gig. **Edited by hand by
+  Adrian.** This is the file to update to add a gig; nothing else in this
+  directory needs to change for that.
+- **`gig-history.html`** / **`gig-history.css`** — the app shell (filters,
+  table, sort/search JS, styling). **Written by the Gig Tracker agent, not by
+  hand**, and only touched when the UI itself changes. Their embedded `let
+  GIGS = [...]` line is a placeholder — it is overwritten at every build with
+  data parsed fresh from `gig-history.md`, so it does not need to be kept in
+  sync.
+
+adrianparker.com rebuilds the page at `/GigTracker/` from all three on every
+build, so whatever they say at build time is what gets published.
 
 `index.njk` is the site's own wrapper and is **not** agent-owned — don't write
 to it.
 
+## The data file format
+
+`gig-history.md` is a markdown table with a header row and separator row,
+followed by one data row per gig, most recent first:
+
+```
+| Date | Performer | Category | City | Country | Venue | Show / Festival |
+|---|---|---|---|---|---|---|
+| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Hadestown: Teen Edition |
+```
+
+All seven columns are required on every row (leave a column blank rather than
+omitting it — see the `Show / Festival` column above). Free text before the
+header (a title, a description paragraph) and after the table (notes) is
+ignored by the parser in `lib/gig-history.mjs`; only lines starting with `|`
+after the header count as rows, and a row with the wrong number of columns is
+skipped.
+
 ## How the embed works
 
-`content/_data/gigTrackerApp.mjs` reads both files at build time and hands them
-to `lib/embed-app.mjs`, which:
+`content/_data/gigTrackerApp.mjs`:
 
-1. takes the contents of `<body>` and throws the `<head>` away
-2. moves the reload controls into a hidden container (see below)
-3. gives every `<button>` an explicit `type="button"`, which the site's HTML
-   validation requires — you don't need to write it, but it's harmless if you do
-4. drops the `:root`, `html` and `body` rules from the CSS
-5. prefixes every remaining selector with `.gig-tracker`
-6. re-declares the app's custom properties in terms of the site's theme tokens
-7. inlines the result into the page
+1. parses `gig-history.md` via `lib/gig-history.mjs` and splices the result
+   into `gig-history.html`'s `let GIGS = [...]` line
+2. hands the result, plus `gig-history.css`, to `lib/embed-app.mjs`, which:
+   1. takes the contents of `<body>` and throws the `<head>` away
+   2. moves the reload controls into a hidden container (see below)
+   3. gives every `<button>` an explicit `type="button"`, which the site's
+      HTML validation requires — you don't need to write it, but it's
+      harmless if you do
+   4. drops the `:root`, `html` and `body` rules from the CSS
+   5. prefixes every remaining selector with `.gig-tracker`
+   6. re-declares the app's custom properties in terms of the site's theme
+      tokens
+   7. inlines the result into the page
 
-Neither source file is served. There is no `/GigTracker/gig-history.html`.
+None of the three source files is served. There is no
+`/GigTracker/gig-history.html` or `/GigTracker/gig-history.md`.
 
 ## Rules to follow
 

--- a/content/GigTracker/gig-history.md
+++ b/content/GigTracker/gig-history.md
@@ -1,0 +1,475 @@
+# Adrian's Gig History
+
+A log of live gigs (concerts, comedy, theatre, orchestra, ballet, opera, and spoken word) extracted from Adrian's Google Calendar (adrian@iceknife.com), sourced from calendar events titled "GIG ...", and from Adrian's paper notebook of gigs attended 1986-1999 (see gig-notebook.md). City, Country, and Venue are cross-checked against Gmail ticket confirmation emails (label: Tickets), with web search as a fallback where no matching email was found.
+Data has been manually improved, validated and some gigs identified in gigs-missing-from-history.md have been merged in. Do not remove any entries from this list ever. Do not edit any entry in this list without Adrian's express, explicit, and timely confirmation.
+
+**Date range covered:** 1986-03-04 to 2026-06-27
+
+**Most recent GIG in this file: 2026-06-27 — Hadestown: Teen Edition** — when updating this log, only fetch calendar events after this date.
+
+| Date | Performer | Category | City | Country | Venue | Show / Festival |
+|---|---|---|---|---|---|---|
+| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Hadestown: Teen Edition |
+| 2026-06-23 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Hadestown: Teen Edition |
+| 2026-05-23 | Teen Jesus and the Jean Teasers, Ivy | Music | Wellington | New Zealand | San Fran |  |
+| 2026-05-01 | Fat Freddy's Drop | Music | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2026-03-20 | The Datsuns, Warm Leather | Music | Wellington | New Zealand | San Fran |  |
+| 2026-03-01 | Werewolf | Theatre | Wellington | New Zealand | Circa Theatre | Werewolf |
+| 2026-02-27 | Transvision Vamp, Dropper | Music | Wellington | New Zealand | Meow Nui |  |
+| 2026-02-06 | Jim Jefferies | Comedy | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2025-11-26 | Pixies, Elliot & Vincent | Music | Wellington | New Zealand | St James Theatre |  |
+| 2025-11-22 | Beastwars, Soft Bait, Pull Down The Sun | Music | Wellington | New Zealand | Meow Nui |  |
+| 2025-10-21 | Commodores | Music | Wellington | New Zealand | St James Theatre |  |
+| 2025-10-10 | 2:22 A Ghost Story | Theatre | Wellington | New Zealand | Circa Theatre | 2:22 A Ghost Story |
+| 2025-08-19 | Mamma Mia | Theatre | Wellington | New Zealand | St James Theatre | Mamma Mia |
+| 2025-05-09 | The Addams Family: A New Musical | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | The Addams Family: A New Musical |
+| 2025-03-23 | Kristin Hersh, Jon Muq | Music | Wellington | New Zealand | Old St Paul's |  |
+| 2025-03-16 | Shihad, The Boondocks | Music | Wellington | New Zealand | Meow Nui |  |
+| 2025-02-02 | Kurtis Conner | Comedy | Wellington | New Zealand | The Opera House |  |
+| 2024-12-29 | Shihad, Sublime, Home Brew, Ladyhawke, Elemeno P | Music | New Plymouth | New Zealand | Bowl of Brooklands | Rock The Bowl 2024 |
+| 2024-07-07 | Sense and Sensibility | Theatre | Wellington | New Zealand | Circa Theatre | Sense and Sensibility |
+| 2024-02-25 | The National, The Beths | Music | Wellington | New Zealand | TSB Arena |  |
+| 2024-01-27 | Simple Minds, Texas, Collective Soul, Pseudo Echo | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2024 |
+| 2023-12-07 | Come Together | Music | Wellington | New Zealand | St James Theatre | The Best of Come Together - Big End of Year Bash 2023 |
+| 2023-11-12 | Robbie Williams, Ladyhawke | Music | Napier | New Zealand | Mission Estate Winery |  |
+| 2023-03-18 | Shihad, Devilskin, Villainy, The Feelers, Racing, Che Fu | Music | Wellington | New Zealand | Waitangi Park | Jim Beam Homegrown 2023 |
+| 2023-02-04 | ZZ Top, Pat Benatar, Stone Temple Pilots, The Angels | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2023 |
+| 2023-02-02 | Ed Sheeran, Kaylee Bell, Maisie Peters | Music | Wellington | New Zealand | Sky Stadium |  |
+| 2023-01-28 | Cowboy Junkies | Music | Wellington | New Zealand | The Opera House |  |
+| 2022-12-14 | Pixies, Anthonie Tonnon | Music | Wellington | New Zealand | The Opera House |  |
+| 2022-12-08 | Guns N' Roses, Alien Weaponry, The Chats | Music | Wellington | New Zealand | Sky Stadium |  |
+| 2022-11-24 | David Gray | Music | Wellington | New Zealand | TSB Arena |  |
+| 2022-10-22 | George Thorogood & The Destroyers | Music | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2022-09-23 | The Beths | Music | Wellington | New Zealand | The Opera House |  |
+| 2022-08-20 | Reb Fountain, Jazmine Mary | Music | Wellington | New Zealand | The Opera House |  |
+| 2022-07-07 | Come Together | Music | Wellington | New Zealand | The Opera House | Rumours |
+| 2022-07-02 | Hollie Smith | Music | Wellington | New Zealand | Meow |  |
+| 2022-06-25 | Teeks, NZ Symphony Orchestra | Music | Wellington | New Zealand | St James Theatre | Guest appearance by Hollie Smith |
+| 2021-12-10 | Mel Parsons | Music | Wellington | New Zealand | Meow |  |
+| 2021-06-12 | The Nathan Haines Octet | Music | Wellington | New Zealand | The Opera House |  |
+| 2021-05-22 | Beastwars, Earth Tongue | Music | Wellington | New Zealand | The Hunter Lounge |  |
+| 2021-05-21 | Ben Elton | Comedy | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2021-04-03 | The Artist | Theatre | Wellington | New Zealand | Circa Theatre | The Artist |
+| 2021-03-15 | Crowded House, Reb Fountain | Music | Wellington | New Zealand | TSB Arena |  |
+| 2020-11-25 | Come Together | Music | Wellington | New Zealand | The Opera House | Come Together - Dire Straits' Brothers In Arms |
+| 2020-11-21 | Shapeshifter, Tiki Taane | Music | Wellington | New Zealand | TSB Arena |  |
+| 2020-10-17 | Thomas Oliver | Music | Wellington | New Zealand | The Opera House |  |
+| 2020-10-09 | The Beths | Music | Wellington | New Zealand | San Fran |  |
+| 2020-10-03 | Whole Lotta Led | Music | Wellington | New Zealand | The Opera House |  |
+| 2020-03-07 | Beastwars, Uncle Acid and the Deadbeats, Witchskull, Earth Tongue | Music | Upper Hutt | New Zealand | Panhead Brewery | Obey the Riff |
+| 2020-02-23 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Glass / Richter / Jarvi |
+| 2020-02-05 | Queen + Adam Lambert | Music | Wellington | New Zealand | Sky Stadium |  |
+| 2020-01-25 | Billy Idol, George Thorogood, Anastasia, Smash Mouth | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2020 |
+| 2019-09-16 | Fleetwood Mac | Music | Auckland | New Zealand | Spark Arena |  |
+| 2019-07-24 | Hilltop Hoods, Jordan Lee | Music | Auckland | New Zealand | The Studio |  |
+| 2019-06-08 | Hollie Smith | Music | Wellington | New Zealand | The Thistle Inn |  |
+| 2019-06-05 | Herbie Hancock | Music | Wellington | New Zealand | Michael Fowler Centre | Wellington Jazz Festival 2019 |
+| 2019-05-03 | Jordan Luck, Ekko Park | Music | Wellington | New Zealand | San Fran |  |
+| 2019-03-05 | The Jesus and Mary Chain, Shoddy | Music | Wellington | New Zealand | The Opera House |  |
+| 2019-03-02 | Eminem, Hilltop Hoods | Music | Wellington | New Zealand | Westpac Stadium |  |
+| 2019-02-23 | Trinity Roots, The Beths, C.W. Stoneking, The Miltones | Music | Paraparaumu | New Zealand | Southward's Car Museum | Coastella |
+| 2019-02-06 | Jon Toogood | Music | Wellington | New Zealand | Meow |  |
+| 2018-11-26 | Whose Line Is It Anyway | Comedy | Wellington | New Zealand | The Opera House | Whose Line Is It Anyway |
+| 2018-11-08 | Trinity Roots | Music | Wellington | New Zealand | The Opera House |  |
+| 2018-10-20 | Shihad, Beastwars, Villainy | Music | Wellington | New Zealand | Shed 6 | Shihad 30 |
+| 2018-10-13 | Don McGlashan | Music | Wellington | New Zealand | Old St Paul's |  |
+| 2018-09-13 | Chicago | Theatre | Wellington | New Zealand | The Opera House | Chicago |
+| 2018-07-13 | Beastwars, Earth Tongue, Slumbug | Music | Wellington | New Zealand | San Fran |  |
+| 2017-12-14 | Alt-J, Warpaint | Music | Wellington | New Zealand | TSB Arena |  |
+| 2017-09-14 | Hollie Smith, Mark Vanilau | Music | Wellington | New Zealand | San Fran |  |
+| 2017-07-09 | Rhys Darby | Comedy | Wellington | New Zealand | The Opera House |  |
+| 2017-06-09 | Dianne Reeves | Music | Wellington | New Zealand | The Opera House | Wellington Jazz Festival 2017 |
+| 2017-05-20 | Head Like A Hole, Hiboux | Music | Wellington | New Zealand | Valhalla |  |
+| 2017-05-05 | Thomas Oliver | Music | Auckland | New Zealand | The Tuning Fork |  |
+| 2017-04-28 | Ed Byrne | Comedy | Wellington | New Zealand | The Opera House |  |
+| 2017-04-22 | The Darkness, Push Push | Music | Christchurch | New Zealand | The Foundry |  |
+| 2017-03-23 | Adele | Music | Auckland | New Zealand | Mount Smart Stadium |  |
+| 2017-03-10 | Pixies, Cut Off Your Hands | Music | Wellington | New Zealand | TSB Arena |  |
+| 2017-02-05 | James Taylor | Music | Napier | New Zealand | Church Road Winery |  |
+| 2017-02-02 | Guns N' Roses, Wolfmother | Music | Wellington | New Zealand | Westpac Stadium |  |
+| 2016-12-04 | Ben Harper, Miller Yule | Music | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2016-12-03 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | The Planets |
+| 2016-10-26 | Slipknot, Lamb of God | Music | Auckland | New Zealand | Vector Arena |  |
+| 2016-10-20 | Julianna Barwick | Music | Wellington | New Zealand | Caroline |  |
+| 2016-10-15 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Nutcracker |
+| 2016-09-10 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Memory of an Angel |
+| 2016-09-04 | Shaolin Warriors | Theatre | Wellington | New Zealand | St James Theatre | Shaolin Warriors |
+| 2016-07-16 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Capriccio |
+| 2016-06-11 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Odes To Joy |
+| 2016-05-07 | Jim Jefferies | Comedy | Wellington | New Zealand | The Opera House |  |
+| 2016-04-29 | Iron Maiden, The Raven Age | Music | Christchurch | New Zealand | Horncastle Arena |  |
+| 2016-04-22 | Beastwars, The Shocking, Stunning | Music | Wellington | New Zealand | San Fran |  |
+| 2016-04-08 | Hollie Smith | Music | Wellington | New Zealand | San Fran |  |
+| 2016-04-01 | Mick Fleetwood Blues, The Miltones | Music | Wellington | New Zealand | The Opera House |  |
+| 2016-02-26 | The Sword, American Sharks, Clowns | Music | Wellington | New Zealand | Bar Bodega |  |
+| 2015-12-12 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Handel's Messiah |
+| 2015-11-25 | Tame Impala, Silicon | Music | Wellington | New Zealand | Shed 6 |  |
+| 2015-11-21 | Elton John, Sol3 Mio | Music | Wellington | New Zealand | Westpac Stadium |  |
+| 2015-10-13 | Neil Finn | Music | Wellington | New Zealand | The Opera House |  |
+| 2015-10-02 | Devilskin, Sumo Cyco, Curly's Jewels | Music | Wellington | New Zealand | San Fran |  |
+| 2015-09-19 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Classical Hits |
+| 2015-08-31 | Dylan Moran | Comedy | Wellington | New Zealand | St James Theatre |  |
+| 2015-08-13 | Ahoribuzz | Music | Wellington | New Zealand | Meow |  |
+| 2015-06-12 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Wagner Gala |
+| 2015-06-04 | Dee Dee Bridgewater, Irvin Mayfield & The New Orleans Jazz Orchestra | Music | Wellington | New Zealand | The Opera House |  |
+| 2015-05-09 | Motley Crue, Alice Cooper | Music | Auckland | New Zealand | Vector Arena | The Final Tour |
+| 2015-05-03 | Everclear | Music | Wellington | New Zealand | Bar Bodega |  |
+| 2015-04-02 | Billy Idol, Cheap Trick, The Angels | Music | Wellington | New Zealand | TSB Arena |  |
+| 2015-03-29 | Gary Clark Jr, Aaron Tokona | Music | Wellington | New Zealand | Shed 6 |  |
+| 2015-03-01 | Slipknot, Marilyn Manson, Slash, Fall Out Boy, Judas Priest, The Smashing Pumpkins | Music | Sydney | Australia | Olympic Park | Soundwave Festival |
+| 2015-02-18 | Slash, Devilskin | Music | Wellington | New Zealand | TSB Arena |  |
+| 2015-02-14 | Supergroove, Dave Dobbyn, Don McGlashan, Anika Moa | Music | Martinborough | New Zealand | Luna Estate | The Winery Tour 2015 |
+| 2015-01-24 | Heart, Foreigner, 3 Dog Night | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2015 |
+| 2014-12-19 | The Datsuns | Music | Wellington | New Zealand | San Fran |  |
+| 2014-10-31 | Lorde | Music | Wellington | New Zealand | TSB Arena |  |
+| 2014-10-10 | Beastwars, Windhand, Mermaidens | Music | Wellington | New Zealand | San Fran |  |
+| 2014-09-30 | Dire Straits Experience | Music | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2014-09-19 | Boy and Bear, Mali Mali, Alexander Wildwood | Music | Wellington | New Zealand | Bar Bodega |  |
+| 2014-08-28 | Kristin Hersh | Music | Wellington | New Zealand | Bar Bodega |  |
+| 2014-08-08 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Mahler's 9th |
+| 2014-06-13 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Beethoven's 4th & 5th |
+| 2014-06-06 | Chick Corea & Gary Burton | Music | Wellington | New Zealand | Michael Fowler Centre |  |
+| 2014-05-11 | Billy Connolly | Comedy | Wellington | New Zealand | TSB Arena |  |
+| 2014-05-03 | Arctic Monkeys, Pond | Music | Wellington | New Zealand | TSB Arena |  |
+| 2014-04-27 | Steve Earle and the Dukes, The Mastersons | Music | Wellington | New Zealand | St James Theatre |  |
+| 2014-03-20 | Nine Inch Nails, Queens Of The Stone Age | Music | Wellington | New Zealand | TSB Arena |  |
+| 2014-03-14 | Kimbra, Arrested Development, Tim Finn, Pokey Lafarge | Music | New Plymouth | New Zealand | Bowl of Brooklands | WOMAD New Zealand |
+| 2013-12-14 | Belinda Carlisle | Music | Wellington | New Zealand | The Opera House |  |
+| 2013-12-02 | Iris DeMent | Music | Wellington | New Zealand | Old St Paul's |  |
+| 2013-11-28 | Rules of Addiction | Music | Wellington | New Zealand | Bar Medusa |  |
+| 2013-10-05 | 8 Foot Sativa, Gunt, Bulletbelt, Gift of Ruin | Music | Wellington | New Zealand | Bar Medusa |  |
+| 2013-09-20 | Fat Freddy's Drop | Music | Wellington | New Zealand | The Opera House |  |
+| 2013-09-12 | The Datsuns, Milk Train | Music | Wellington | New Zealand | Bar Bodega |  |
+| 2013-07-27 | Shapeshifter | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 2013-07-20 | Hairy Maclairy Live | Theatre | Wellington | New Zealand | The Opera House | Hairy Maclairy Live |
+| 2013-05-05 | Tom Green | Comedy | Wellington | New Zealand | The Opera House |  |
+| 2013-05-04 | Unida, Beastwars | Music | Wellington | New Zealand | Bar Bodega |  |
+| 2013-03-19 | Neil Young and Crazy Horse, Husky, The Drones | Music | Wellington | New Zealand | TSB Arena |  |
+| 2012-08-12 | Blur, New Order, The Specials | Music | London | United Kingdom | Hyde Park | BT London Live |
+| 2012-08-01 | Ella Fitzgerald Experience | Music | London | United Kingdom | Ronnie Scott's Jazz Club |  |
+| 2012-07-28 | Eddie Vedder, Glen Hansard | Music | Manchester | United Kingdom | O2 Apollo |  |
+| 2012-07-27 | Hollie Smith | Music | London | United Kingdom | Vandella |  |
+| 2012-07-20 | Rhys Darby | Comedy | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2012-07-17 | Madonna, LMFAO, Martin Solveig | Music | London | United Kingdom | Hyde Park | MDNA Tour |
+| 2012-07-14 | Bruce Springsteen | Music | London | United Kingdom | Hyde Park | Hard Rock Calling. Guest appearances by Paul McCartney, John Fogerty, Tom Morello |
+| 2012-07-13 | Soundgarden, Iggy & the Stooges, Cold Chisel, Black Stone Cherry | Music | London | United Kingdom | Hyde Park | Hard Rock Calling |
+| 2012-07-08 | Faith No More, Guano Padano | Music | London | United Kingdom | Hammersmith Apollo | Guest appearance by Danny DeVito |
+| 2012-07-06 | Deadmau5, The Roots, Santigold, Childish Gambino, Metric | Music | London | United Kingdom | Hyde Park | Wireless Festival |
+| 2012-06-26 | Robert Cray | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2012-06-20 | Tom Petty, Jonathan Wilson | Music | London | United Kingdom | Royal Albert Hall |  |
+| 2012-06-05 | Cypress Hill | Music | London | United Kingdom | The Forum |  |
+| 2012-06-02 | The Sunshine Boys | Theatre | London | United Kingdom | Savoy Theatre | The Sunshine Boys |
+| 2012-05-26 | Judas Priest, Saxon | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2012-05-03 | Jose Gonzalez, Tinariwen | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2012-04-30 | Russian Circles, Wovenhand | Music | London | United Kingdom | Scala |  |
+| 2012-03-25 | Korn, Downlink | Music | London | United Kingdom | Brixton Academy |  |
+| 2012-03-20 | The Phantom Of The Opera | Theatre | London | United Kingdom | Her Majesty's Theatre | The Phantom Of The Opera |
+| 2012-03-15 | Anthrax | Music | London | United Kingdom | Islington Academy |  |
+| 2012-02-26 | Imogen Heap, Ana Silvera | Music | London | United Kingdom | Roundhouse |  |
+| 2012-02-06 | Gilby Clarke, Badmouth | Music | London | United Kingdom | Underworld Camden |  |
+| 2012-01-29 | Throwing Needles | Music | London | United Kingdom |  |  |
+| 2011-12-18 | The Royal Ballet | Other | London | United Kingdom | Royal Opera House | The Nutcracker |
+| 2011-12-14 | Def Leppard, Motley Crue, Steel Panther | Music | London | United Kingdom | Wembley Arena |  |
+| 2011-11-26 | Dave Dobbyn | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2011-11-22 | Wye Oak | Music | London | United Kingdom | XOYO |  |
+| 2011-11-19 | Bob Dylan, Mark Knopfler | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2011-11-15 | Roxette, Darren Hayes | Music | London | United Kingdom | Wembley Arena |  |
+| 2011-11-02 | Throwing Muses, Spectrals | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2011-10-29 | Alice Cooper, New York Dolls, Arthur Brown | Music | London | United Kingdom | Alexandra Palace | Guest appearance by Lou Reed |
+| 2011-10-27 | Lenny Kravitz | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2011-10-18 | Marketa Irglova | Music | London | United Kingdom | Bush Hall |  |
+| 2011-10-12 | Brett Anderson | Music | London | United Kingdom | KOKO |  |
+| 2011-10-01 | Von Hertzen Brothers | Music | London | United Kingdom | Borderline |  |
+| 2011-09-02 | Doug Stanhope | Comedy | London | United Kingdom | Leicester Square Theatre |  |
+| 2011-08-30 | Janes Addiction | Music | London | United Kingdom | KOKO |  |
+| 2011-08-24 | Deftones, Pulled Apart By Horses | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2011-08-13 | Throwing Needles | Music | London | United Kingdom | Punk (Soho) |  |
+| 2011-08-05 | Iron Maiden, DragonForce | Music | London | United Kingdom | The O2 Arena |  |
+| 2011-07-29 | Placido Domingo, Angela Gheorghiu | Opera | London | United Kingdom | The O2 Arena |  |
+| 2011-07-14 | Dylan Moran | Comedy | London | United Kingdom | Hammersmith Apollo |  |
+| 2011-06-30 | Cyndi Lauper, Charlie Musselwhite, Allen Toussaint | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2011-06-28 | BB King | Music | London | United Kingdom | Royal Albert Hall | Guest appearances by Slash, Ronnie Wood, Mick Hucknall, Derek Trucks, Susan Tedeschi |
+| 2011-06-25 | Bon Jovi, Stevie Nicks, Ray Davies, Black Cards, Lissie, Vintage Trouble | Music | London | United Kingdom | Hyde Park | Hard Rock Calling |
+| 2011-06-21 | Ozzy Osbourne | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2011-06-18 | Simple Minds, James Walsh (Starsailor) | Music | Nottingham | United Kingdom | Sherwood Pines Park | Forest Live |
+| 2011-06-11 | Yelawolf | Music | Amsterdam | The Netherlands | Melkweg Oude Zaal |  |
+| 2011-05-22 | The Straits | Music | London | United Kingdom | Royal Albert Hall | The Straits' debut public performance (charity show) |
+| 2011-05-20 | The Naked And Famous | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2011-05-18 | Roger Waters | Music | London | United Kingdom | The O2 |  |
+| 2011-05-16 | Uncaged Monkeys | Comedy | London | United Kingdom | Hammersmith Apollo | Uncaged Monkeys — Brian Cox, Ben Goldacre, Simon Singh, Robin Ince, Helen Arney |
+| 2011-05-05 | Paloma Faith | Music | London | United Kingdom | Union Chapel |  |
+| 2011-04-11 | Jose Gonzalez, Gothenburg String Theory, Little Scream | Music | London | United Kingdom | Barbican Hall |  |
+| 2011-04-08 | Ed Byrne | Comedy | London | United Kingdom | Hammersmith Apollo |  |
+| 2011-04-07 | Kylie Minogue, Ultra Girls | Music | London | United Kingdom | The O2 |  |
+| 2011-03-23 | Cage The Elephant | Music | London | United Kingdom | Electric Ballroom |  |
+| 2011-02-28 | Adler's Appetite | Music | London | United Kingdom | Underworld Camden | Guest appearance by Duff McKagan |
+| 2011-02-25 | Foo Fighters, Cee Lo Green, Band Of Horses, No Age | Music | London | United Kingdom | Wembley Arena | NME Awards Big Gig 2011 |
+| 2011-02-12 | Esben and the Witch | Music | Amsterdam | The Netherlands | Paradiso |  |
+| 2010-11-21 | Soulfly | Music | London | United Kingdom | KOKO |  |
+| 2010-11-19 | Therapy? | Music | London | United Kingdom | HMV Forum |  |
+| 2010-11-17 | Deftones, Coheed and Cambria | Music | London | United Kingdom | Brixton Academy |  |
+| 2010-11-11 | Linkin Park, Does It Offend You Yeah? | Music | London | United Kingdom | The O2 |  |
+| 2010-10-23 | Morcheeba | Music | London | United Kingdom | Roundhouse |  |
+| 2010-10-20 | Stephen Hawking | Other | London | United Kingdom | Royal Albert Hall |  |
+| 2010-10-13 | Guns N' Roses, Sebastian Bach | Music | London | United Kingdom | The O2 |  |
+| 2010-09-25 | Zodiac Mindwarp | Music | London | United Kingdom | Borderline |  |
+| 2010-07-24 | The Prodigy, Pendulum, Chase & Status, Enter Shikari | Music | Milton Keynes | United Kingdom | Milton Keynes Bowl | Warriors Dance Festival |
+| 2010-07-22 | Sepultura, Gama Bomb | Music | London | United Kingdom | Scala |  |
+| 2010-07-17 | Penn & Teller | Comedy | London | United Kingdom | Hammersmith Apollo |  |
+| 2010-06-29 | Melissa Etheridge | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2010-06-27 | Paul McCartney, Crowded House, Crosby Stills & Nash, Elvis Costello | Music | London | United Kingdom | Hyde Park | Hard Rock Calling |
+| 2010-06-04 | Pixies | Music | London | United Kingdom | Troxy |  |
+| 2010-06-03 | Love Never Dies | Theatre | London | United Kingdom | Adelphi Theatre | Love Never Dies |
+| 2010-05-31 | Sunny Day Real Estate, Biffy Clyro | Music | London | United Kingdom | HMV Forum |  |
+| 2010-05-24 | Hope Sandoval, Dirt Blue Gene | Music | London | United Kingdom | Bush Hall |  |
+| 2010-05-04 | Belinda Carlisle | Music | London | United Kingdom | Jazz Cafe |  |
+| 2010-04-28 | Ricky Gervais | Comedy | London | United Kingdom | Wembley Arena |  |
+| 2010-04-13 | Joe Perry Project | Music | London | United Kingdom | 100 Club |  |
+| 2010-04-01 | Airbourne, Black Spiders, Taking Dawn | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2010-02-20 | Depeche Mode, Nitzer Ebb | Music | London | United Kingdom | The O2 Arena |  |
+| 2009-12-19 | Nine Lessons and Carols for Godless People | Comedy | London | United Kingdom | UCL Bloomsbury | Nine Lessons and Carols for Godless People |
+| 2009-12-10 | Marilyn Manson, Esoterica | Music | London | United Kingdom | Brixton Academy |  |
+| 2009-12-09 | Placebo, Silversun Pickups, The Horrors | Music | London | United Kingdom | The O2 Arena |  |
+| 2009-12-02 | W.A.S.P., The Glitterati | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2009-11-19 | Julian Clary | Comedy | London | United Kingdom | Leicester Square Theatre |  |
+| 2009-11-17 | Alice In Chains, Little Fish | Music | London | United Kingdom | HMV Forum |  |
+| 2009-11-12 | Biffy Clyro, Manchester Orchestra | Music | London | United Kingdom | Brixton Academy |  |
+| 2009-11-05 | Othello | Theatre | London | United Kingdom | Trafalgar Studios | Othello |
+| 2009-11-01 | Europe | Music | London | United Kingdom | Relentless Garage |  |
+| 2009-10-28 | ZZ Top, Steel Panther | Music | London | United Kingdom | Wembley Arena |  |
+| 2009-10-10 | The Cult, Aqua Nebula Oscillator | Music | London | United Kingdom | Royal Albert Hall |  |
+| 2009-10-07 | Pixies | Music | London | United Kingdom | Brixton Academy |  |
+| 2009-09-24 | JTQ + The Ronnie Scott's All Stars | Music | London | United Kingdom | Ronnie Scott's Jazz Club |  |
+| 2009-09-19 | Coldplay, Jay-Z, White Lies, Girls Aloud | Music | London | United Kingdom | Wembley Stadium |  |
+| 2009-09-17 | Massive Attack | Music | London | United Kingdom | Brixton Academy |  |
+| 2009-09-16 | Dame Kiri Te Kanawa | Opera | London | United Kingdom | The Tower of London | Continental Airlines Tower Festival |
+| 2009-09-04 | Doug Stanhope | Comedy | London | United Kingdom | Leicester Square Theatre |  |
+| 2009-08-29 | Sasha & Digweed, David Guetta, Eric Prydz, Armin Van Buuren, Above & Beyond, Richie Hawtin | Music | London | United Kingdom | Clapham Common | South West Four (SW4) 2009 |
+| 2009-08-27 | Deftones, Rival Schools | Music | London | United Kingdom | HMV Forum |  |
+| 2009-08-18 | Pearl Jam | Music | London | United Kingdom | The O2 Arena |  |
+| 2009-08-04 | Alice In Chains | Music | London | United Kingdom | Scala |  |
+| 2009-07-04 | Jeff Beck, Imelda May, Tal Wilkenfeld | Music | London | United Kingdom | Royal Albert Hall | Guest appearance by David Gilmour |
+| 2009-06-28 | Bruce Springsteen, Dave Matthews Band, James Morrison, The Gaslight Anthem | Music | London | United Kingdom | Hyde Park | Hard Rock Calling |
+| 2009-06-27 | Neil Young, The Pretenders, Seasick Steve, Fleet Foxes, Ben Harper & Relentless7 | Music | London | United Kingdom | Hyde Park | Hard Rock Calling |
+| 2009-06-26 | AC/DC, The Answer, The Subways | Music | London | United Kingdom | Wembley Stadium |  |
+| 2009-06-25 | Chicken Foot, Skin | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2009-06-18 | Tesla | Music | London | United Kingdom | Islington Academy |  |
+| 2009-06-16 | Anthrax, Trigger the Bloodshed, Suicide Silence | Music | London | United Kingdom | ULU |  |
+| 2009-06-10 | Faith No More, Selfish Cunt | Music | London | United Kingdom | Brixton Academy |  |
+| 2009-06-06 | James Taylor Quartet | Music | London | United Kingdom | 100 Club |  |
+| 2009-06-03 | Waiting for Godot | Theatre | London | United Kingdom | Theatre Royal Haymarket | Waiting for Godot |
+| 2009-05-05 | Therapy? | Music | London | United Kingdom | Islington Academy |  |
+| 2009-05-03 | Gary Moore | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2009-03-30 | Sinead O'Connor | Music | London | United Kingdom | The Pigalle Club |  |
+| 2009-03-28 | Metallica, Machine Head, The Sword | Music | London | United Kingdom | The O2 Arena |  |
+| 2009-03-13 | Oliver | Theatre | London | United Kingdom | Theatre Royal Drury Lane | Oliver |
+| 2009-02-21 | Judas Priest, Megadeth, Testament | Music | London | United Kingdom | Wembley Arena |  |
+| 2009-02-19 | The Datsuns | Music | London | United Kingdom | Underworld Camden |  |
+| 2008-12-21 | Nine Lessons and Carols for Godless People | Comedy | London | United Kingdom | Hammersmith Apollo | Nine Lessons and Carols for Godless People |
+| 2008-12-17 | Biffy Clyro, Frightened Rabbit, People in Planes | Music | London | United Kingdom | Brixton Academy |  |
+| 2008-12-10 | Bill Bailey | Comedy | London | United Kingdom | Gielgud Theatre |  |
+| 2008-12-07 | Coldplay | Music | Glasgow | United Kingdom | SECC |  |
+| 2008-12-03 | Slipknot, Machine Head, Children of Bodom | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2008-11-25 | Dylan Moran | Comedy | London | United Kingdom | Hammersmith Apollo |  |
+| 2008-11-23 | Kristin Hersh | Music | London | United Kingdom | Borderline |  |
+| 2008-11-05 | Bryan Adams | Music | London | United Kingdom | The O2 |  |
+| 2008-10-26 | Cypress Hill | Music | London | United Kingdom | Battersea Power Station |  |
+| 2008-10-24 | Aimee Mann, The Submarines | Music | London | United Kingdom | IndigO2 (The O2) |  |
+| 2008-10-02 | Seasick Steve, Amy LaVere | Music | London | United Kingdom | Royal Albert Hall |  |
+| 2008-09-30 | Brett Anderson, Kid Harpoon | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2008-09-26 | LA Guns, Love/Hate | Music | London | United Kingdom | Islington Academy |  |
+| 2008-09-23 | Nigel Kennedy Quintet | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2008-09-18 | Duff McKagen | Music | London | United Kingdom | Islington Academy |  |
+| 2008-09-17 | Doug Stanhope | Comedy | London | United Kingdom | Arts Theatre |  |
+| 2008-09-16 | Riflemind starring John Hannah | Theatre | London | United Kingdom | Trafalgar Studios | Riflemind |
+| 2008-09-13 | Allanah Myles | Music | London | United Kingdom | The Underworld |  |
+| 2008-09-09 | The Datsuns | Music | London | United Kingdom | Barfly |  |
+| 2008-08-31 | Heaven and Hell, Motorhead, Judas Priest, Testament | Music | California | United States of America | Shoreline Ampitheatre | Metal Masters Tour |
+| 2008-08-24 | Metallica, Tenacious D, Slipknot, Feeder, Avenged Sevenfold, Dropkick Murphys | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival |
+| 2008-08-20 | Maceo Parker | Music | London | United Kingdom | The Pigalle Club |  |
+| 2008-08-13 | Lenny Kravitz, Sons of Albion | Music | London | United Kingdom | Brixton Academy |  |
+| 2008-07-31 | Billy Idol | Music | London | United Kingdom | Brixton Academy |  |
+| 2008-07-20 | Nigel Kennedy, BBC Concert Orchestra | Orchestra | London | United Kingdom | Royal Albert Hall | BBC Proms 2008 |
+| 2008-07-19 | Jill Scott | Music | London | United Kingdom | Brixton Academy |  |
+| 2008-07-16 | Fat Pig | Theatre | London | United Kingdom | Trafalgar Studios | Fat Pig |
+| 2008-07-13 | The Year of Magical Thinking | Theatre | London | United Kingdom | National Theatre | The Year of Magical Thinking |
+| 2008-07-10 | The Frontline | Theatre | London | United Kingdom | Shakespeare's Globe | The Frontline |
+| 2008-07-05 | Iron Maiden, Avenged Sevenfold, Within Temptation, Lauren Harris | Music | London | United Kingdom | Twickenham Stadium |  |
+| 2008-07-03 | Duran Duran, The Duke Spirit, The Real People | Music | London | United Kingdom | The O2 |  |
+| 2008-06-28 | Eric Clapton, Sheryl Crow, John Mayer, Jason Mraz, Robert Randolph and The Family Band, Steve Boyce Band | Music | London | United Kingdom | Hyde Park | Hard Rock Calling |
+| 2008-06-27 | Bon Jovi, The Feeling, Ivy Rise | Music | London | United Kingdom | Twickenham Stadium |  |
+| 2008-06-26 | Def Leppard, Whitesnake, Black Stone Cherry | Music | London | United Kingdom | Wembley Arena |  |
+| 2008-06-15 | Radiohead, Bat For Lashes | Music | Nimes | France | Arènes de Nîmes |  |
+| 2008-06-10 | The Herbaliser | Music | London | United Kingdom | 93 Feet East |  |
+| 2008-05-29 | We Will Rock You | Theatre | London | United Kingdom | Dominion Theatre | We Will Rock You |
+| 2008-05-27 | Mark Knopfler, Bap Kennedy | Music | London | United Kingdom | Royal Albert Hall |  |
+| 2008-05-23 | Public Enemy, Dr Octagon (Kool Keith), Kutmasta Kurt, Edan, Anti Pop Consortium, MC Dagha | Music | London | United Kingdom | Brixton Academy |  |
+| 2008-05-17 | The Trailer Boat Ride | Music | London | United Kingdom |  |  |
+| 2008-04-17 | The Breeders | Music | London | United Kingdom | KOKO |  |
+| 2008-04-15 | Hollie Smith | Music | London | United Kingdom | Neighbourhood |  |
+| 2008-04-12 | Jose Gonzalez | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2008-04-10 | Portishead | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2008-04-09 | Black Crowes | Music | London | United Kingdom | Brixton Academy |  |
+| 2008-04-08 | English National Opera | Opera | London | United Kingdom | London Coliseum | David Lynch's Lost Highway |
+| 2008-03-20 | The Cure | Music | London | United Kingdom | Wembley Arena |  |
+| 2008-03-16 | Neil Young | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2008-03-07 | Apocolyptica | Music | London | United Kingdom | The Forum, Kentish Town |  |
+| 2008-03-01 | Speed-the-plow | Theatre | London | United Kingdom | The Old Vic | Speed-the-plow |
+| 2008-02-24 | Tiesto, Ferry Corsten, Marco V, Sander van Doorn | Music | Utrecht | The Netherlands | Jaarbeurs (Trance Energy) | Trance Energy |
+| 2008-02-16 | Ninja Tune, The Bug (Flowdan), Plastician, Ghislain Poirier, Bonobo, DJ Food, Coldcut (Jon More), zero dB, The Death Set, X Rabit | Music | London | United Kingdom | Electrowerkz | Ninja Tune presents You Don't Know |
+| 2008-02-02 | Great White | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2007-12-13 | Chemical Bros, Simian Mobile Disco | Music | London | United Kingdom | Brixton Academy |  |
+| 2007-11-29 | Macbeth | Theatre | London | United Kingdom | Gielgud Theatre | Macbeth |
+| 2007-11-28 | English National Opera | Opera | London | United Kingdom | London Coliseum | Aida |
+| 2007-11-24 | Amy Winehouse | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2007-11-23 | The Hives | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2007-11-17 | Alice Cooper, Motorhead, Joan Jett | Music | London | United Kingdom | Wembley Arena |  |
+| 2007-11-16 | Gary Moore | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2007-11-14 | Sex Pistols | Music | London | United Kingdom | Brixton Academy |  |
+| 2007-11-10 | Heaven and Hell, Lamb of God, Iced Earth | Music | London | United Kingdom | Wembley Arena |  |
+| 2007-11-09 | Lez Zeppelin | Music | London | United Kingdom | London Astoria |  |
+| 2007-11-05 | Tesla, Killing For Company | Music | London | United Kingdom | Islington Academy |  |
+| 2007-11-02 | W.A.S.P. | Music | London | United Kingdom | London Astoria |  |
+| 2007-10-23 | LCD Soundsystem | Music | London | United Kingdom | Brixton Academy |  |
+| 2007-10-18 | Underworld | Music | London | United Kingdom | Roundhouse |  |
+| 2007-10-11 | Turin Brakes | Music | London | United Kingdom | The Forum |  |
+| 2007-10-09 | Swimming with Sharks | Theatre | London | United Kingdom | Vaudeville Theatre | Swimming with Sharks |
+| 2007-10-06 | Amp Fiddler | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2007-09-29 | Russell Brand | Comedy | London | United Kingdom | Hackney Empire |  |
+| 2007-09-18 | Kosheen | Music | London | United Kingdom | KOKO |  |
+| 2007-09-07 | The Jesus and Mary Chain, The Horrors, Evan Dando | Music | London | United Kingdom | Brixton Academy |  |
+| 2007-09-06 | Beastie Boys | Music | London | United Kingdom | Roundhouse |  |
+| 2007-08-26 | The Smashing Pumpkins, Nine Inch Nails, Lostprophets, Fall Out Boy, Funeral for a Friend, The Used, Billy Talent | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival |
+| 2007-08-25 | Red Hot Chili Peppers, Arcade Fire, Bloc Party, Panic! At The Disco, Angels and Airwaves, Eagles of Death Metal, Paramore, Unkle, Biffy Clyro, The Shins, Dinosaur Jr | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival |
+| 2007-08-24 | Razorlight, Kings of Leon, Interpol, Maximo Park, Jimmy Eat World, Gossip, Gogol Bordello, Ash, Brand New | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival |
+| 2007-08-10 | BBC Concert Orchestra | Orchestra | London | United Kingdom | Royal Albert Hall | BBC Proms 36 |
+| 2007-07-15 | Frank Black | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2007-07-08 | Metallica, Machine Head, Mastodon, H.I.M. | Music | London | United Kingdom | Wembley Stadium |  |
+| 2007-07-07 | Madonna, Red Hot Chili Peppers, Genesis, Duran Duran, Metallica, Foo Fighters, Beastie Boys, Snow Patrol, Keane, Black Eyed Peas, John Legend, David Gray, Damien Rice, Corinne Bailey Rae, James Blunt, Kasabian, Bloc Party, Paolo Nutini, Pussycat Dolls | Music | London | United Kingdom | Wembley Stadium | Live Earth |
+| 2007-06-17 | Muse, Biffy Clyro, My Chemical Romance | Music | London | United Kingdom | Wembley Stadium |  |
+| 2007-03-12 | Avenue Q | Theatre | London | United Kingdom | Noel Coward Theatre | Avenue Q |
+| 2007-02-15 | Indigo Girls | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2007-02-06 | Wolfmother | Music | London | United Kingdom | Hammersmith Apollo |  |
+| 2006-12-23 | Iron Maiden, Trivium, Lauren Harris | Music | London | United Kingdom | Earls Court |  |
+| 2006-12-03 | The Zutons | Music | London | United Kingdom | Roundhouse |  |
+| 2006-11-27 | Tool, Mastodon | Music | London | United Kingdom | Wembley Arena |  |
+| 2006-11-17 | W.A.S.P., Jaded | Music | London | United Kingdom | London Astoria |  |
+| 2006-11-12 | Bruce Springsteen | Music | London | United Kingdom | Wembley Arena | Guest appearance by Nils Lofgren |
+| 2006-11-08 | The Datsuns | Music | London | United Kingdom | Electric Ballroom |  |
+| 2006-11-07 | INXS | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2006-10-21 | Salmonella Dub | Music | London | United Kingdom | Shepherd's Bush Empire |  |
+| 2006-10-08 | Sander Kleinenberg, Mark Knight, Sebastien Leger, Martijn Ten Velden, Nick Bridges | Music | London | United Kingdom | Ministry of Sound |  |
+| 2006-09-16 | English National Opera | Opera | London | United Kingdom | Coliseum | Gaddafi: A Living Myth |
+| 2006-09-12 | Pearl Jam, My Morning Jacket | Music | Paris | France | Palais Omnisports de Paris-Bercy |  |
+| 2006-08-26 | Sander Kleinenberg, Steve Lawler, Carl Cox, Paul Oakenfold, John Digweed, Pete Tong, Judge Jules, Seb Fontaine, Danny Howells, Fergie, The Shapeshifters, Mauro Picotto, Stanton Warriors, Nic Fanciulli, Sander van Doorn, Desyn Masiello, James Zabiela, Ian Betts, Matt Hardwick | Music | London | United Kingdom | Clapham Common | South West Four (SW4) 2006 |
+| 2006-06-17 | Foo Fighters, Motorhead, Queens Of The Stone Age, Angels and Airwaves, Juliette & The Licks, The Subways | Music | London | United Kingdom | Hyde Park | Guest appearances by Lemmy, Brian May, Roger Taylor |
+| 2003-04-24 | Morcheeba | Music | Wellington | New Zealand | Wellington Town Hall | |
+| 2002-07-11 | The Breeders | Music | San Francisco | United States of America | The Fillmore |  |
+| 2002-07-05 | The Cranberries | Music | Los Angeles | United States of America | Greek Theatre |  |
+| 1999-05-30 | Beastie Boys, DJ Mix Master Mike | Music | Wellington | New Zealand | Wellington Town Hall | |
+| 1999-04-17 | Keb' Mo', Paul Ubana Jones | Music | Wellington | New Zealand | State Opera House |  |
+| 1999-03-15 | Jaunt, The Whores Next Door, Pushkin | Music | Wellington | New Zealand | Indigo |  |
+| 1998-11-27 | Pushkin, The Whores Next Door, Broomdance | Music | Wellington | New Zealand | Indigo |  |
+| 1998-11-13 | Bongmaster, Hell Is Other People, Shihad | Music | Wellington | New Zealand | James Cabaret |  |
+| 1998-10-24 | Salvage, Whores Next Door, Wretched Skinny, Empty Quarter | Music | Wellington | New Zealand | Black Kat Cafe |  |
+| 1998-10-09 | The Living End, Brubeck | Music | Wellington | New Zealand | James Cabaret |  |
+| 1998-10-01 | Whores Next Door, Tau, Empty Quarter | Music | Wellington | New Zealand | Indigo |  |
+| 1998-09-25 | Whores, Empty Quarter, Wretched Skinny, Trawler, Big Blue Blanket | Music | Wellington | New Zealand | Black Kat Cafe |  |
+| 1998-09-18 | Fur Patrol, Weta | Music | Wellington | New Zealand | Indigo |  |
+| 1998-09-14 | Death In June | Music | Wellington | New Zealand | Indigo |  |
+| 1998-09-03 | The Whores Next Door, Lamps, Pushkats | Music | Wellington | New Zealand | Indigo |  |
+| 1998-08-21 | The Whores Next Door, Empty Quarter | Music | Wellington | New Zealand | Black Kat Cafe |  |
+| 1998-08-19 | The Whores Next Door, Trinity, Salvage | Music | Wellington | New Zealand | Victoria University of Wellington | Battle of the Bands |
+| 1998-07-25 | Alex Paterson, Coda | Music | Wellington | New Zealand | Escape |  |
+| 1998-06-13 | Whores Next Door, Wretched Skinny | Music | Wellington | New Zealand | Black Kat Cafe |  |
+| 1998-04-09 | Breathe, The Stereo Bus, Tim Finn, DLT & Che Fu, Head Like A Hole | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1998-04-08 | Portishead | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1998-03-10 | Cassandra Wilson | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1998-02-19 | Foo Fighters, Weta | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1998-01-29 | Radiohead | Music | Wellington | New Zealand | Queens Wharf Events Centre |  |
+| 1997-10-03 | Bike, Breakfast of Champions | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1997-07-05 | Faith No More, Better Than Ezra, The Nixons, Orbit, Muse | Music | Fort Lauderdale | United States of America | Markham Park | Zetafest |
+| 1997-04-05 | Head Like A Hole | Music | Wellington | New Zealand | Civic Square |  |
+| 1997-03-13 | Baconfoot, Snitches, Gas Huffer | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1997-03-07 | Head Like A Hole, Frenzal Rhomb | Music | Wellington | New Zealand | Union Hall |  |
+| 1997-03-05 | Superette | Music | Wellington | New Zealand | Union Hall |  |
+| 1997-03-04 | David Harrow, Salmonella Dub | Music | Wellington | New Zealand | Union Hall |  |
+| 1997-02-22 | ENZSO (Split Enz / NZ Symphony Orchestra) | Music | Upper Hutt | New Zealand | Trentham Memorial Park |  |
+| 1997-02-21 | Letterbox Lambs, Superette | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1997-01-22 | The Exponents, Pash | Music | Wellington | New Zealand | James Cabaret |  |
+| 1997-01-16 | Soundgarden, Weta | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1997-01-05 | Weta, Breathe, Short | Music | Wellington | New Zealand | Civic Square |  |
+| 1996-12-18 | The Warners | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1996-05-10 | Shihad | Music | Wellington | New Zealand | James Cabaret |  |
+| 1996-05-04 | Red Hot Chilli Peppers, Thorazine Shuffle | Music | Wellington | New Zealand | Events Centre |  |
+| 1996-04-10 | Atomic Blossom | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1996-01-19 | Skwish | Music | Wellington | New Zealand |  |  |
+| 1996-01-11 | Knightshade, Dave Dobbyn, Muttonbirds, Joe Satriani, Stranglers, The Cruel Sea, Mental As Anything, The Exponents, Barry Saunders, Head Like A Hole, Pumpkinhead | Music | Woodville | New Zealand | Airlie Brae | Mountain Rock 5 |
+| 1995-10-01 | Skwish | Music | Wellington | New Zealand | Cuba Cuba |  |
+| 1995-08-11 | Shihad, Short | Music | Wellington | New Zealand | James Cabaret |  |
+| 1995-08-05 | Faith No More, Pumpkinhead, Dead Flowers | Music | Wellington | New Zealand | Wellington Show + Sports Centre |  |
+| 1995-08-04 | Letterbox Lambs, Breathe | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1995-08-02 | Condition Red | Music | Wellington | New Zealand | Antipodes |  |
+| 1995-07-31 | Dave Dobbyn, Emma Paki | Music | Wellington | New Zealand | James Cabaret |  |
+| 1995-05-25 | Sweet Family Unit | Music | Wellington | New Zealand | Antipodes |  |
+| 1995-04-01 | Squirm | Music | Wellington | New Zealand | Antipodes |  |
+| 1995-01-19 | The Cult, Fat Mannequin | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1995-01-14 | No Thrills, Head Like A Hole, Greg Johnson, Yothu Yindi, The Exponents, Tama Renata, Upper Hutt Posse, Brainchilds, Muttonbirds, Supergroove, Midnight Oil, Dave Dobbyn, Tim Finn, Semi Lemon Kola | Music | Woodville | New Zealand |  | Mountain Rock IV |
+| 1994-12-22 | Stonor, Nefretete, Wormhole, Rollie Stones | Music | Lower Hutt | New Zealand | Lucky Jacks |  |
+| 1994-12-17 | Stonor | Music | Grenada North | New Zealand | Warehouse |  |
+| 1994-12-09 | Slink Patrol, Skwish, Stonor | Music | Wellington | New Zealand | Thistle Hall |  |
+| 1994-11-30 | Tori Amos, Ted Brown | Music | Auckland | New Zealand | Auckland Town Hall |  |
+| 1994-11-26 | Stonor | Music | Lower Hutt | New Zealand | Miller Bar |  |
+| 1994-11-18 | Stonor | Music | Wellington | New Zealand | 38 Norway St |  |
+| 1994-11-06 | Pantera, Fat Mannequin | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1994-11-02 | Skwish, Plankton | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1994-10-05 | Beastie Boys, Helmet, Emulsifier | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1994-08-27 | Supergroove, Nixons, MCOJ & DLT | Music | Wellington | New Zealand | James Cabaret |  |
+| 1994-08-04 | Skwish | Music | Wellington | New Zealand | Bar Bodega |  |
+| 1994-07-23 | Supergroove, Thorazine Shuffle, DLT | Music | Wellington | New Zealand | James Cabaret |  |
+| 1994-07-01 | Head Like A Hole, Monster | Music | Wellington | New Zealand | Union Hall |  |
+| 1994-06-23 | Kristin Hersh, Brainchilds | Music | Wellington | New Zealand | Paramount Theatre |  |
+| 1994-05-27 | Burning Roses, The Crystalline | Music | Wellington | New Zealand | Union Building, Victoria University |  |
+| 1994-05-21 | Desert Road | Music | Wellington | New Zealand | Metro |  |
+| 1994-04-27 | Muttonbirds, Emma Paki, Bilge Festival | Music | Wellington | New Zealand | James Cabaret |  |
+| 1994-03-01 | The 3Ds, Bailter Space, Solid Gold Hell | Music | Wellington | New Zealand | Union Hall |  |
+| 1994-02-27 | JPSE, Cinematic | Music | Wellington | New Zealand | Union Hall |  |
+| 1994-02-05 | Soundgarden, The Smashing Pumpkins, Shihad, Head Like A Hole, Muttonbirds, JPSE, Breeders, Urge Overkill, Hard-Ons, Jan Hellriegel, Cruel Sea, Kid Eternity, Freedom, Crowded House, Dave Dobbyn, Annie Crummer | Music | Wellington | New Zealand | Wellington Town Hall | Big Day Out |
+| 1994-02-04 | Boney M | Music | Hamilton | New Zealand | Hamilton Domain |  |
+| 1994-01-15 | Supergroove, Andrew Fagan, The Warratahs, R. Bryant, K Borich, Hello Sailor, Jan Hellriegel, Dave Dobbyn, Shona Laing, Straitjacket Fits, Desert Road, The Exponents, Drawn, Wildfire, Shihad, Head Like A Hole, Dead Flowers | Music | Woodville | New Zealand |  | Mountain Rock III |
+| 1994-01-14 | Dave Dobbyn, The Exponents | Music | Wellington | New Zealand | James Cabaret |  |
+| 1993-12-17 | Premature Autopsy, Loves Ugly Children, Head Like A Hole, Shihad | Music | Wellington | New Zealand | Union Hall |  |
+| 1993-11-18 | Karnage, Warpspasm, Carcass | Music | Wellington | New Zealand | Stox |  |
+| 1993-09-16 | Glass Candle Grenade, Wake | Music | Wellington | New Zealand | Kaminskys |  |
+| 1993-09-12 | Living Colour, Big Deal | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1993-08-15 | Wellington Youth Choir, Manawatu Youth Choir | Music | Wellington | New Zealand |  |  |
+| 1993-07-28 | Pungent Stench, Tension, Warp Drive | Music | Wellington | New Zealand | Kaminskys |  |
+| 1993-07-23 | Shihad, Skinshed, Flail | Music | Wellington | New Zealand | James Cabaret |  |
+| 1993-07-02 | Head Like A Hole, Steak, Funkmutha | Music | Wellington | New Zealand | Stox |  |
+| 1993-05-22 | Push Push, The Spirals | Music | Wellington | New Zealand | Show & Sports Centre |  |
+| 1993-05-13 | Faith No More, Emulsifier | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1993-04-23 | JPSE | Music | Wellington | New Zealand | Sol Bar |  |
+| 1993-04-17 | Dead Flowers, Andrew Fagan, Big Deal, Ugly Truth, Open Oyster, Wildfire | Music | Wellington | New Zealand | Shed 11 |  |
+| 1993-04-03 | Shihad, Conventional Toasters, Funkmutha | Music | Wellington | New Zealand | James Cabaret |  |
+| 1993-03-04 | JPSE, Muttonbirds | Music | Wellington | New Zealand | Union Hall |  |
+| 1993-03-02 | The Lemonheads, David Kilgour, Bilge Festival | Music | Wellington | New Zealand | Union Hall |  |
+| 1993-02-25 | Billy Connolly | Comedy | Wellington | New Zealand | Michael Fowler Centre |  |
+| 1993-02-06 | Guns N' Roses, Skid Row, Dead Flowers | Music | Auckland | New Zealand | Mount Smart Stadium |  |
+| 1993-01-16 | Shona Laing, Sam Hunt, Push Push, Shihad, Muttonbirds, Ted Clarke, Jan Hellriegel, Desert Road, Nine Livez, Dead Flowers, Southside of Bombay, Big Deal, Blue Buffoons, Flippin Hippies, Savana, Johnny B Band, Out of the Blue, Snowline | Music | Woodville | New Zealand | Airlie Brae | Mountain Rock II |
+| 1993-01-11 | Jenny Morris, JPSE | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1993-01-02 | Archies Aunts, Charlotte Sometimes, Shona Laing,  Merenia | Music | Wellington | New Zealand | Civic Square |  |
+| 1992-12-10 | Malchicks, The Exponents | Music | Wellington | New Zealand | James Cabaret |  |
+| 1992-11-08 | Still, Kamikaze Daydream | Music | Wellington | New Zealand | Dragons |  |
+| 1992-08-13 | The Cure, Jan Hellriegel | Music | Wellington | New Zealand | Wellington Town Hall |  |
+| 1992-05-17 | Scarf | Music | Hastings | New Zealand | Club Ew-els |  |
+| 1992-04-16 | Braintree, Shihad | Music | Wellington | New Zealand | New Carpark |  |
+| 1992-04-03 | Buddakhan, The Exponents | Music | Wellington | New Zealand | New Carpark |  |
+| 1992-03-07 | Scios, Slaine, Sacrament, Deliverance, Vas Deferens | Music | Wellington | New Zealand | New Carpark |  |
+| 1992-01-25 | Midge Marsden, Push Push, Dick Thrust, Shihad, Desert Road, Southside of Bombay, Lets Planet, Big Deal, Thin Fish, Head Like A Hole, Ralph Bennett, Dave Murphy, Luke Hurcey, Johnny B Band, Wild Fire, Serpentine, Bullfrog Rata, Blue Smoke, Sam Hunt, Vandrix, Helter Skelter | Music | Woodville | New Zealand | | Mountain Rock |
+| 1992-01-24 | Buddakhan | Music | Wellington | New Zealand | New Carpark |  |
+| 1992-01-01 | Push Push, The Exponents | Music | Napier | New Zealand | Onekawa Rockgarden |  |
+| 1991-12-28 | Ted Clarke, Backdoor Blues | Music | Hastings | New Zealand | Stortford Lodge |  |
+| 1991-11-14 | Shihad, AC/DC | Music | Wellington | New Zealand | Athletic Park |  |
+| 1991-09-27 | Scios, NIHL, Sacrament, Josephine Bewitched, Deliverance | Music | Wellington | New Zealand | Empire Warehouse |  |
+| 1991-04-10 | Jeff Healey, Midge Marsden | Music | Wellington | New Zealand | St James Theatre |  |
+| 1986-03-04 | Dire Straits, Satellite Spies | Music | Wellington | New Zealand | Athletic Park |  |

--- a/content/_data/gigTrackerApp.mjs
+++ b/content/_data/gigTrackerApp.mjs
@@ -4,6 +4,12 @@
   what the site publishes. They are written by a separate agent and are not
   edited here — see content/GigTracker/README.md for the contract they follow.
 
+  The gig data itself is not read from the HTML's own `let GIGS = [...]` line
+  — that line is replaced below with data parsed fresh from
+  content/GigTracker/gig-history.md on every build, so updating that one
+  markdown file and rebuilding is enough to publish new gigs, with no need to
+  regenerate or hand-copy the HTML/CSS shell.
+
   All the logic lives in lib/embed-app.mjs; this file is the site-specific
   half: which controls to drop, and what the app's palette means in terms of
   the site's own theme tokens.
@@ -12,9 +18,11 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { buildAppEmbed } from "../../lib/embed-app.mjs";
+import { parseGigHistory } from "../../lib/gig-history.mjs";
 
 const APP_DIR = path.join(import.meta.dirname, "..", "GigTracker");
 const SCOPE = ".gig-tracker";
+const GIGS_ASSIGNMENT = /let GIGS = \[.*\];/;
 
 /*
   The reload controls re-read gig-history.md off disk, which is how the app
@@ -60,8 +68,12 @@ const LITERAL_COLOURS = {
 };
 
 export default function () {
+  const gigs = parseGigHistory(fs.readFileSync(path.join(APP_DIR, "gig-history.md"), "utf8"));
+  const html = fs.readFileSync(path.join(APP_DIR, "gig-history.html"), "utf8")
+    .replace(GIGS_ASSIGNMENT, `let GIGS = ${JSON.stringify(gigs)};`);
+
   const embed = buildAppEmbed({
-    html: fs.readFileSync(path.join(APP_DIR, "gig-history.html"), "utf8"),
+    html,
     css: fs.readFileSync(path.join(APP_DIR, "gig-history.css"), "utf8"),
     scope: SCOPE,
     quarantineIds: QUARANTINED_CONTROLS,

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -46,20 +46,23 @@ export default function (eleventyConfig) {
 
   /*
     The Gig Tracker's source files and their contract doc. gig-history.html is
-    a standalone document written by a separate agent, and Eleventy would
-    otherwise treat it — and the README — as templates, publishing orphaned,
-    unlinked pages at /GigTracker/gig-history/ and /GigTracker/README/. Same
-    trap as the EXIF Viewer's own shell above (#45).
+    a standalone document written by a separate agent, gig-history.md is the
+    gig data Adrian edits by hand, and Eleventy would otherwise treat all
+    three markdown/HTML files — and the README — as templates, publishing
+    orphaned, unlinked pages at /GigTracker/gig-history/ and
+    /GigTracker/README/. Same trap as the EXIF Viewer's own shell above (#45).
 
     The sources are not passthrough-copied either: content/_data/gigTrackerApp.mjs
     reads them at build time and embeds the result into the page, so nothing
-    here needs to be served. Watched explicitly so `npm run serve` picks up the
-    agent's edits, which it cannot infer from an ignored file.
+    here needs to be served. Watched explicitly so `npm run serve` picks up
+    edits, which it cannot infer from an ignored file.
   */
   eleventyConfig.ignores.add("content/GigTracker/gig-history.html");
+  eleventyConfig.ignores.add("content/GigTracker/gig-history.md");
   eleventyConfig.ignores.add("content/GigTracker/README.md");
   eleventyConfig.addWatchTarget("content/GigTracker/gig-history.html");
   eleventyConfig.addWatchTarget("content/GigTracker/gig-history.css");
+  eleventyConfig.addWatchTarget("content/GigTracker/gig-history.md");
 
   // render a markdown string as HTML in place
   eleventyConfig.addFilter("md", renderMarkdown);

--- a/lib/gig-history.mjs
+++ b/lib/gig-history.mjs
@@ -1,0 +1,50 @@
+/*
+  Parses content/GigTracker/gig-history.md into the row data the Gig Tracker
+  app needs. The file is a hand-maintained markdown table with a header row
+  ("| Date | Performer | ... |"), a separator row ("|---|---|..."), and one
+  data row per gig — see content/GigTracker/README.md for the exact contract.
+*/
+
+const COLUMNS = ["date", "performer", "category", "city", "country", "venue", "show"];
+
+function isSeparatorRow (line) {
+  return line.startsWith("|---");
+}
+
+function isHeaderRow (line) {
+  return line.startsWith("| Date");
+}
+
+function parseRow (line) {
+  const cells = line.split("|").map((cell) => cell.trim());
+
+  // A well-formed "| a | b | ... |" line splits into one empty string
+  // before the first "|" and one after the last, plus a cell per column.
+  if (cells.length !== COLUMNS.length + 2) { return null; }
+
+  const fields = cells.slice(1, -1);
+  return Object.fromEntries(COLUMNS.map((name, i) => [name, fields[i]]));
+}
+
+/**
+ * Extracts gig rows from the markdown table. Lines before the header, the
+ * header and separator rows themselves, and anything after the table (a
+ * trailing blank line, notes, EOF) are ignored. A data row with the wrong
+ * number of columns is skipped rather than thrown on, since the file is
+ * hand-edited.
+ */
+export function parseGigHistory (markdown) {
+  const lines = markdown.split("\n").map((line) => line.trim());
+  const headerIndex = lines.findIndex(isHeaderRow);
+  if (headerIndex === -1) { return []; }
+
+  const rows = [];
+  for (const line of lines.slice(headerIndex + 1)) {
+    if (isSeparatorRow(line)) { continue; }
+    if (!line.startsWith("|")) { break; }
+
+    const row = parseRow(line);
+    if (row) { rows.push(row); }
+  }
+  return rows;
+}

--- a/tests/unit/gig-history.test.mjs
+++ b/tests/unit/gig-history.test.mjs
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import { parseGigHistory } from "../../lib/gig-history.mjs";
+
+const TABLE = [
+  "# Adrian's Gig History",
+  "",
+  "Some description text.",
+  "",
+  "| Date | Performer | Category | City | Country | Venue | Show / Festival |",
+  "|---|---|---|---|---|---|---|",
+  "| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Hadestown: Teen Edition |",
+  "| 2026-05-01 | Fat Freddy's Drop | Music | Wellington | New Zealand | Michael Fowler Centre |  |"
+].join("\n");
+
+describe("gig-history — parseGigHistory", () => {
+  it("parses each data row into a gig object", () => {
+    const rows = parseGigHistory(TABLE);
+    expect(rows).to.have.lengthOf(2);
+    expect(rows[0]).to.deep.equal({
+      date: "2026-06-27",
+      performer: "Hadestown: Teen Edition",
+      category: "Theatre",
+      city: "Paraparaumu",
+      country: "New Zealand",
+      venue: "Coastlands Theatre",
+      show: "Hadestown: Teen Edition"
+    });
+  });
+
+  it("keeps an empty show field as an empty string", () => {
+    const rows = parseGigHistory(TABLE);
+    expect(rows[1].show).to.equal("");
+  });
+
+  it("stops at the first line after the table that is not a row", () => {
+    const withTrailer = `${TABLE}\n\nSome trailing note.\n`;
+    expect(parseGigHistory(withTrailer)).to.have.lengthOf(2);
+  });
+
+  it("skips a data row with the wrong number of columns", () => {
+    const withBadRow = `${TABLE}\n| 2026-01-01 | Missing Columns |`;
+    expect(parseGigHistory(withBadRow)).to.have.lengthOf(2);
+  });
+
+  it("returns an empty array when there is no header row", () => {
+    expect(parseGigHistory("just some text\nwith no table\n")).to.deep.equal([]);
+  });
+
+  it("returns an empty array for an empty file", () => {
+    expect(parseGigHistory("")).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `content/GigTracker/gig-history.md` (the same table Adrian previously maintained in a Cowork project folder) as the in-repo source of truth for gig data.
- Adds `lib/gig-history.mjs` (`parseGigHistory`), a pure, fully unit-tested markdown-table parser.
- `content/_data/gigTrackerApp.mjs` now parses `gig-history.md` on every build and splices the result into the `let GIGS = [...]` line of the (rarely-changing) `gig-history.html` app shell, before the existing `lib/embed-app.mjs` scoping/theming pipeline runs.
- Updates `eleventy.config.mjs` to ignore/watch the new markdown file, same treatment as the existing `gig-history.html`/`README.md`.
- Updates `content/GigTracker/README.md`'s contract doc to describe the new split: `gig-history.md` is hand-edited data, `gig-history.html`/`.css` are the agent-authored shell.

Closes #91. Net effect: updating a gig is now edit `content/GigTracker/gig-history.md` → `npm run build`, with no external Cowork step and no manual file copy.

## Test plan
- [x] `npm run test:unit` — new parser at 100% coverage, all existing tests pass
- [x] `npm run test:smoke` — 49 passing, embed contract still holds (data inlined, no orphaned pages, reload controls quarantined, CSS scoped)
- [x] Diffed the build's generated `GIGS` array against the previously hand-copied array in `gig-history.html` — 464/464 rows, byte-identical
- [x] Loaded `/Gig-History/` in a browser: correct row count (464), most recent gig (2026-06-27 Hadestown: Teen Edition) at the top, filters/table intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)