### PR TITLE
Fix nanoid DoS vulnerability (Dependabot #79)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3878,9 +3878,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.7",
-    "diff": "^9.0.0"
+    "diff": "^9.0.0",
+    "nanoid": "^3.3.18"
   },
   "devDependencies": {
     "c8": "^12.0.0",


### PR DESCRIPTION
## Summary
- Adds `nanoid` to `overrides` in `package.json`, pinning it to `>=3.3.18` to resolve [GHSA-2v37-7h3g-55p8](https://github.com/adrianparker/adrianparker.github.io/security/dependabot/79) (high severity)
- `nanoid` is a transitive dependency via `exifcmdline -> vite -> postcss`, pulled in at 3.3.17 (vulnerable to indefinite loop when a custom generator's size is 0)
- `npm audit` now reports 0 vulnerabilities

## Test plan
- [x] `npm install` — resolves `nanoid@3.3.18`, 0 vulnerabilities
- [x] `npm run test:unit` — 113 passing, 100% coverage on all four metrics