### PR TITLE
Fix spelling typos, add security.txt, CSP/referrer meta, image dimensions

### DIFF
--- a/content/_includes/partials/head.njk
+++ b/content/_includes/partials/head.njk
@@ -77,7 +77,7 @@
   theme-toggle.njk, and the appInlineStyles block above) — tracked as a
   follow-up issue to drop 'unsafe-inline' once those are nonced/hashed.
 #}
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://*.i.posthog.com https://*.flickr.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.staticflickr.com https://www.setlist.fm; font-src 'self'; connect-src 'self' https://*.posthog.com https://*.i.posthog.com; frame-src https://*.flickr.com; form-action 'self' https://adrianparker.us6.list-manage.com; object-src 'none'; base-uri 'self';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://*.i.posthog.com https://*.flickr.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.staticflickr.com https://www.setlist.fm; font-src 'self'; connect-src 'self' https://*.posthog.com https://*.i.posthog.com; media-src 'self' https://*.cloudfront.net; frame-src https://*.flickr.com; form-action 'self' https://adrianparker.us6.list-manage.com; object-src 'none'; base-uri 'self';">
 <meta name="referrer" content="strict-origin-when-cross-origin">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="generator" content="{{ eleventy.generator }}">

--- a/content/_includes/partials/head.njk
+++ b/content/_includes/partials/head.njk
@@ -66,6 +66,19 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ currentUrl | url }}">
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+{#
+  GitHub Pages serves this site with no way to set real HTTP response
+  headers, so this is the closest available approximation. `<meta>` CSP
+  can't carry frame-ancestors (browsers ignore it there), and headers like
+  X-Frame-Options/Permissions-Policy have no meta-tag form at all — those
+  stay unset until the site sits behind a proxy/CDN that can inject them.
+  'unsafe-inline' is still needed by a handful of un-nonced inline
+  <script>/<style> blocks (this file, analytics.njk, app-nav.njk,
+  theme-toggle.njk, and the appInlineStyles block above) — tracked as a
+  follow-up issue to drop 'unsafe-inline' once those are nonced/hashed.
+#}
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://*.i.posthog.com https://*.flickr.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.staticflickr.com https://www.setlist.fm; font-src 'self'; connect-src 'self' https://*.posthog.com https://*.i.posthog.com; frame-src https://*.flickr.com; form-action 'self' https://adrianparker.us6.list-manage.com; object-src 'none'; base-uri 'self';">
+<meta name="referrer" content="strict-origin-when-cross-origin">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="generator" content="{{ eleventy.generator }}">
 <meta name="description" content="{{ metadesc }}">

--- a/content/posts/Last-Ever-Last-Ever.md
+++ b/content/posts/Last-Ever-Last-Ever.md
@@ -138,7 +138,7 @@ acoustic jam tours... it felt like a natural end when I heard the news. The end 
 Their advertised last ever gig on the tour was Homegrown, a festival in Wellington. 
 Tickets to Homegrown were too expensive for me though given Shihad were the only band I wanted to see. 
 
-Luckily, they were also playing an outdoor ampitheatre in New Plymouth, on a day I was going to be there on holiday. 
+Luckily, they were also playing an outdoor amphitheatre in New Plymouth, on a day I was going to be there on holiday. 
 My mate Paul who played bass in a band I was in,  Phuego, lives in New Plymouth and was keen to go too. 
 Great chance to catch up with an old friend *and* rock out to Shihad one last time. 
 

--- a/content/posts/Wine-Cork-Notice-Board-How-To.md
+++ b/content/posts/Wine-Cork-Notice-Board-How-To.md
@@ -8,7 +8,7 @@ readingtime: '3 minutes'
 ---
 ## How to make a Wine Cork Notice Board
 
-I'm not generally regarded as an arts and crafts type of person. Arts, perhaps, especially the musical kind; and crafty, sure, I can identify with that; but put the two words together and generally thats's enough to make me run for the hills.
+I'm not generally regarded as an arts and crafts type of person. Arts, perhaps, especially the musical kind; and crafty, sure, I can identify with that; but put the two words together and generally that's enough to make me run for the hills.
 
 However I've been collecting wine corks for seemingly forever, and the last couple of years I've been assiduously putting off this project, until last weekend when I said to myself, you know what, get it done. And so I did. 
 
@@ -35,7 +35,7 @@ Like any good online tutorial, we begin with the ingredients. You will need:
  - Instruct small person to cut the corks length ways, preserving the most interesting details
  - Cutting corks is easier if you cut multiple times...
    - cut the whole length each time 
-   - only cut a a third of the depth each time
+   - only cut a third of the depth each time
    - three shallow cuts is much easier that one full depth cut
    - Set to one side any offcuts
  - If the frame has glass, take that out so you just have the backing board and the frame
@@ -48,7 +48,7 @@ Like any good online tutorial, we begin with the ingredients. You will need:
    - Remember to fill all the gaps, using offcuts cut to shape
  - Starting top left, glue in the remaining corks length ways with interesting text facing outwards
    - Aiming to fill the frame top to bottom left to right with straight corks when possible
- - Glue offcuts in the small gaps that inevitable appear until there are no gaps left
+ - Glue offcuts in the small gaps that inevitably appear until there are no gaps left
  
 {% image "img/IMG_7120.jpg", "The finished wine cork notice board" %}
 

--- a/lib/shortcodes.mjs
+++ b/lib/shortcodes.mjs
@@ -79,6 +79,8 @@ export const imageShortcode = async (
   const imgAttributes = stringifyAttributes({
     src: largestJpeg.url,
     alt,
+    width: largestJpeg.width,
+    height: largestJpeg.height,
     loading: "lazy",
     decoding: "async"
   });

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:adrian@iceknife.com
+Expires: 2027-08-18T00:00:00.000Z
+Preferred-Languages: en

--- a/tests/unit/shortcodes.test.mjs
+++ b/tests/unit/shortcodes.test.mjs
@@ -141,6 +141,14 @@ describe("shortcodes — imageShortcode", () => {
     expect(html).to.contain('alt="A test caption"');
   });
 
+  it("sets width and height on the img fallback to prevent layout shift", () => {
+    const img = html.match(/<img [^>]*>/)[0];
+    const maxWidth = Math.max(...IMAGE_WIDTHS);
+    // fixture is a 4:3 image (1000x750), so height should scale proportionally
+    expect(img).to.contain(`width="${maxWidth}"`);
+    expect(img).to.contain(`height="${Math.round((maxWidth * 750) / 1000)}"`);
+  });
+
   it("sets lazy loading and async decoding", () => {
     expect(html).to.contain('loading="lazy"');
     expect(html).to.contain('decoding="async"');


### PR DESCRIPTION
## Summary

From an audit of nine potential issues Adrian flagged (RSS/Atom link, spelling, security.txt, security headers, image performance, nav keyboard a11y, Mailchimp form a11y, H1 headings). Full findings and rationale for each: several were already fine (Atom feed link already present and sufficient; main nav already plain keyboard-friendly links; Mailchimp email field already has a proper `<label for>`; all four index pages already have a visually-hidden `<h1>`). This PR covers the ones that were real:

- Fix 4 spelling typos across 2 posts (Wine Cork Notice Board, Last Ever Last Ever).
- Add `/.well-known/security.txt` (RFC 9116, contact only).
- Add a CSP + Referrer-Policy `<meta>` tag to `head.njk` — the closest approximation available on GitHub Pages, which has no way to set real HTTP response headers. `X-Frame-Options`, `Permissions-Policy`, `X-Content-Type-Options`, COOP/CORP/COEP have no meta-tag equivalent and stay unset; HSTS is already auto-applied by GitHub Pages. Verified against real page loads in a browser — PostHog analytics and the Flickr embedr widget both load cleanly under the policy (had to correct the origins twice against actual network behaviour: PostHog serves from `*.i.posthog.com` as well as `*.posthog.com`, and Flickr's embed script loads from `widgets.flickr.com`, not the `embedr.flickr.com` origin its `<script src>` names).
- Set `width`/`height` on the image shortcode's `<img>` fallback (`lib/shortcodes.mjs`) so the browser reserves space before the image loads, cutting layout shift. `eleventy-img` already returns this metadata, so it was just unused.

## Follow-ups (deferred, tracked as issues)

- #99 — app-nav hamburger menu has no Escape-to-close or focus management.
- #100 — CSP still needs `'unsafe-inline'` because of several un-nonced inline `<script>`/`<style>` blocks.

## Test plan

- [x] `npm run test:unit` — 100% coverage maintained, new test added for the `width`/`height` attributes.
- [x] `npm run build` — spot-checked `_site/.well-known/security.txt`, the CSP/referrer meta tags, and `width`/`height` on built `<img>` output.
- [x] `npm run test:smoke` — passing.
- [x] `npm test` (full suite incl. visual regression) — 118 passing, no baseline diffs.
- [x] Manually loaded a real gig page with a `flickr` field in the browser preview and confirmed via devtools that PostHog and Flickr's scripts (including the actual `widgets.flickr.com` embed script) load with zero CSP violations under the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)