### PR TITLE
Show a focus-style indicator for active Gig Tracker filters

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -10,6 +10,7 @@ How to run, maintain and troubleshoot the tests for adrianparker.github.io.
 | **Smoke** (`tests/smoke.test.mjs`) | The build produced the right pages, with the right structure | ~60ms | yes |
 | **Theme** (`tests/theme.test.mjs`) | Light/dark toggle behaviour, persistence, no-JS fallback | ~35s | no, local only |
 | **Analytics** (`tests/analytics.test.mjs`) | PostHog config, custom events, no third-party requests | ~18s | no, local only |
+| **Gig Tracker** (`tests/gig-tracker.test.mjs`) | Filter "active" indicator matches real focus, in both themes | ~20s | no, local only |
 | **Visual regression** (`tests/visual-regression.test.mjs`) | Rendered appearance, against committed baseline screenshots | ~55s | no, local only |
 
 Mocha for running, Chai for assertions, c8 for coverage, cheerio for DOM
@@ -22,6 +23,7 @@ npm run test:unit      # unit tests + coverage gate. No build, no browser
 npm run test:smoke     # build + smoke tests
 npm run test:theme     # build + light/dark theme behaviour
 npm run test:analytics # build + PostHog config and custom events
+npm run test:gigtracker # build + gig tracker filter active indicator
 npm run test:visual    # build + visual regression
 npm test               # everything
 npm run test:headless  # build + smoke only — what the deploy workflow runs

--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -51,9 +51,28 @@ h1 {
   cursor: pointer;
   color: var(--muted);
 }
-.filters button:hover {
+.filters button:hover,
+.filters button.is-active {
   color: var(--text);
+}
+.filters button:hover {
   border-color: var(--accent);
+}
+/*
+  .is-active marks a control that currently has a non-default value (a filter
+  chosen, text typed in search, or — for the reset button — any filter
+  active). It shares this rule with :focus-visible so the "something is set
+  here" indicator is pixel-identical to real focus, by construction rather
+  than by matching colours independently. See tests/smoke.test.mjs.
+*/
+.filters select:focus-visible,
+.filters input:focus-visible,
+.filters button:focus-visible,
+.filters select.is-active,
+.filters input.is-active,
+.filters button.is-active {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 .count {
   color: var(--muted);

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -148,7 +148,19 @@ function sortRows(rows) {
   return sortDir === "asc" ? sorted : sorted.reverse();
 }
 
+function updateActiveIndicators() {
+  let anyActive = searchTerm !== "";
+  Object.keys(filterIds).forEach(key => {
+    const isActive = !!filters[key];
+    if (isActive) anyActive = true;
+    document.getElementById(filterIds[key]).classList.toggle("is-active", isActive);
+  });
+  document.getElementById("search").classList.toggle("is-active", searchTerm !== "");
+  document.getElementById("reset").classList.toggle("is-active", anyActive);
+}
+
 function render() {
+  updateActiveIndicators();
   const filtered = applyFilters(GIGS);
   const sorted = sortRows(filtered);
   const tbody = document.getElementById("tbody");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "serve": "npx eleventy --serve",
     "debug": "DEBUG=* npx eleventy",
     "test:theme": "npm run build && mocha tests/theme.test.mjs --timeout 60000",
-    "test:analytics": "npm run build && mocha tests/analytics.test.mjs --timeout 60000"
+    "test:analytics": "npm run build && mocha tests/analytics.test.mjs --timeout 60000",
+    "test:gigtracker": "npm run build && mocha tests/gig-tracker.test.mjs --timeout 60000"
   },
   "repository": {
     "type": "git",

--- a/tests/gig-tracker.test.mjs
+++ b/tests/gig-tracker.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Behavioural tests for the Gig Tracker filter bar's "active" indicator.
+ *
+ * A filter or the search box gets a persistent outline whenever it has a
+ * non-default value, so it's visible which filters are active without
+ * needing focus. The CSS in gig-history.css deliberately shares one rule
+ * between :focus-visible and .is-active (see the comment there) so the two
+ * are pixel-identical by construction — this test checks that construction
+ * holds, in both themes. If it ever fails, the shared rule has drifted apart
+ * and the indicator needs fixing to match focus again.
+ */
+
+import { expect } from 'chai';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
+
+// Its own port: theme holds 3001, analytics 3002, visual 3000.
+const PORT = 3003;
+const BASE = `http://localhost:${PORT}`;
+
+describe('Gig Tracker filter active indicator', function () {
+  this.timeout(60000);
+
+  let browser;
+
+  before(async function () {
+    await startServer(PORT);
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  });
+
+  after(async function () {
+    if (browser) await browser.close();
+    await stopServer();
+  });
+
+  async function open(colorScheme) {
+    const context = await browser.newContext({ viewport: { width: 1200, height: 800 }, colorScheme });
+    const page = await context.newPage();
+    await page.goto(`${BASE}/Gig-History/index.html`, { waitUntil: 'networkidle' });
+    return { context, page };
+  }
+
+  const outlineOf = (page, selector) =>
+    page.$eval(selector, (el) => getComputedStyle(el).outline);
+
+  ['dark', 'light'].forEach((colorScheme) => {
+    describe(`${colorScheme} mode`, function () {
+      it('gives a select the same outline when active as when focused', async function () {
+        const { context, page } = await open(colorScheme);
+
+        const unfocused = await outlineOf(page, '#f-performer');
+        await page.focus('#f-performer');
+        const focused = await outlineOf(page, '#f-performer');
+        expect(focused, 'focus changes the outline').to.not.equal(unfocused);
+        await page.evaluate(() => document.getElementById('f-performer').blur());
+
+        await page.selectOption('#f-performer', { index: 1 });
+        const active = await outlineOf(page, '#f-performer');
+        expect(active, 'active outline matches focus outline').to.equal(focused);
+
+        await context.close();
+      });
+
+      it('gives the search box the same outline when active as when focused', async function () {
+        const { context, page } = await open(colorScheme);
+
+        await page.focus('#search');
+        const focused = await outlineOf(page, '#search');
+        await page.type('#search', 'alice');
+        const active = await outlineOf(page, '#search');
+        expect(active, 'active outline matches focus outline').to.equal(focused);
+
+        await context.close();
+      });
+
+      it('gives the reset button the same outline when a filter is active as when focused', async function () {
+        const { context, page } = await open(colorScheme);
+
+        await page.focus('#reset');
+        const focused = await outlineOf(page, '#reset');
+        await page.evaluate(() => document.getElementById('reset').blur());
+
+        await page.selectOption('#f-venue', { index: 1 });
+        const active = await outlineOf(page, '#reset');
+        expect(active, 'active outline matches focus outline').to.equal(focused);
+
+        await context.close();
+      });
+
+      it('gives the reset button label the same colour when a filter is active as when hovered', async function () {
+        const { context, page } = await open(colorScheme);
+        const colorOf = (sel) => page.$eval(sel, (el) => getComputedStyle(el).color);
+
+        const resting = await colorOf('#reset');
+        await page.hover('#reset');
+        const hovered = await colorOf('#reset');
+        expect(hovered, 'hover changes the label colour').to.not.equal(resting);
+        await page.mouse.move(0, 0);
+
+        await page.selectOption('#f-venue', { index: 1 });
+        const active = await colorOf('#reset');
+        expect(active, 'active label colour matches hover colour').to.equal(hovered);
+
+        await context.close();
+      });
+
+      it('clears the indicator when filters are reset', async function () {
+        const { context, page } = await open(colorScheme);
+
+        const baseline = await outlineOf(page, '#f-performer');
+        await page.selectOption('#f-performer', { index: 1 });
+        expect(await outlineOf(page, '#f-performer'), 'active after selecting').to.not.equal(baseline);
+        expect(await outlineOf(page, '#reset'), 'reset active after selecting').to.not.equal(baseline);
+
+        await page.click('#reset');
+        expect(await outlineOf(page, '#f-performer'), 'inactive after reset').to.equal(baseline);
+        expect(await outlineOf(page, '#reset'), 'reset inactive after reset').to.equal(baseline);
+
+        await context.close();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Selects, the search box, and the reset button in the Gig Tracker filter bar now show a persistent outline (identical to real focus) whenever they have a non-default value, or — for the reset button — whenever any filter is active. Makes it obvious at a glance which filters are set, in both light and dark mode.
- The reset button's label also always shows its hover colour while a filter is active, for the same reason.
- Both share one CSS rule with `:focus-visible`/`:hover` respectively, so the indicator is pixel-identical to real focus/hover by construction, not by coincidentally matching colours.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained (change is outside `lib/`)
- [x] `npm run test:smoke`
- [x] New `tests/gig-tracker.test.mjs` (Playwright, both themes) — verifies active outline/colour matches real focus/hover, and clears on reset
- [x] Manually verified in the browser preview in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)