### PR TITLE
Fix #102: give h3 the title/accent colour

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -530,7 +530,7 @@ p, label, th, td, section>a, .blog-post>ul {
   line-height: 1.5em;
 }
 
-h1, h2, label, a, a:visited, figcaption, .footnote-item, th {
+h1, h2, h3, label, a, a:visited, figcaption, .footnote-item, th {
   color: var(--color-accent);
 }
 
@@ -542,7 +542,7 @@ li>a:visited {
   color: var(--color-text);
 }
 
-h3, p, td, .blog-post>ul {
+p, td, .blog-post>ul {
   color: var(--color-text);
 }
 


### PR DESCRIPTION
## Summary
- h3 shared the Bebas Neue display font with h1/h2 but was styled with `--color-text` (body grey) instead of `--color-accent` (the navy/orange title colour), per #102
- Moves `h3` into the `--color-accent` rule

## Where h3 appears (per the issue's request for manual review)
- No template hardcodes `<h3>` anywhere in `content/**/*.njk`
- The only live `###` markdown heading on the site is the "Appendix" heading in `content/posts/Last-Ever-Last-Ever.md`

## Test plan
- [x] `npm run test:unit` — 114 passing, coverage 100%
- [x] `npm run test:smoke` — 49 passing
- [x] `npm run test:visual` — no new regressions (2 pre-existing failures on `gigtracker-app`, unrelated to this change — confirmed present on `master` before this branch, likely a content-height change from a recent gig addition)
- [x] Verified computed `color` on the Appendix h3 in both themes: `rgb(255, 153, 0)` (#ff9900) in dark, `rgb(28, 79, 140)` (#1c4f8c) in light

🤖 Generated with [Claude Code](https://claude.com/claude-code)