### PR TITLE
Fix #108: filter select outline no longer sticks after returning to All...

### DIFF
--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -92,6 +92,12 @@ function attachFilterListeners() {
         populateFilters();
       }
       render();
+      // A <select> keeps matching :focus-visible after a real interaction
+      // (unlike a <button>), so the shared focus/active outline (#108)
+      // stays showing even once the value is back to "All..." and
+      // .is-active has been removed. Blurring after commit clears it,
+      // matching how the reset button already behaves.
+      sel.blur();
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fixes #108 — after choosing a dropdown value and then choosing "All..." again, the select kept showing the active/focus outline
- Root cause: `.is-active` was correctly removed by `updateActiveIndicators()`, but a `<select>` keeps matching `:focus-visible` after a real mouse/keyboard interaction (unlike a `<button>`, which drops it on click) — and the CSS rule shares its outline between `.is-active` and `:focus-visible` on purpose. So the outline kept showing via `:focus-visible` alone, until the element lost focus some other way.
- Fix: `sel.blur()` once a change is committed, matching how the reset button already behaves.

## A note on test coverage
I initially added a Playwright regression test using `selectOption()`, but it passed even *without* the fix — Playwright's `selectOption()` doesn't reproduce Chromium's real "focus-visible persists after a genuine interaction" behaviour on `<select>`, so it isn't a meaningful automated check here. I removed it rather than leave a test that gives false confidence.

Instead I verified manually in a real browser, reproducing the exact reported scenario (real click focus → change value → change back to "All...") via direct DOM inspection:
- **Without the fix**: `isActive: false`, but `focusVisible: true` and the outline still shows — the bug.
- **With the fix**: `isActive: false`, `focusVisible: false`, outline is `none` — fixed.
- Confirmed `blur()` only runs inside the `change` handler, so normal keyboard tabbing/focus between filters is unaffected.

## Test plan
- [x] `npm run test:unit` — 114 passing, coverage 100%
- [x] `npm run test:smoke` — 49 passing
- [x] `npx mocha tests/gig-tracker.test.mjs` — all 10 existing tests still pass in both themes, including the pixel-identical focus/active outline invariant
- [x] Manual verification in a real browser as described above (before/after comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)