### PR TITLE
Add invisible Setlist.fm ID column to gig-history.md

### DIFF
--- a/content/GigTracker/README.md
+++ b/content/GigTracker/README.md
@@ -25,17 +25,24 @@ to it.
 followed by one data row per gig, most recent first:
 
 ```
-| Date | Show | Category | City | Country | Venue | Notes | Association |
-|---|---|---|---|---|---|---|---|
-| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | | |
+| Date | Show | Category | City | Country | Venue | Notes | Association | Setlist.fm ID |
+|---|---|---|---|---|---|---|---|---|
+| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | | | |
 ```
 
-All eight columns are required on every row (leave a column blank rather than
-omitting it — see the `Notes` and `Association` columns above). Free text before the
-header (a title, a description paragraph) and after the table (notes) is
-ignored by the parser in `lib/gig-history.mjs`; only lines starting with `|`
-after the header count as rows, and a row with the wrong number of columns is
-skipped.
+All nine columns are required on every row (leave a column blank rather than
+omitting it — see the `Notes`, `Association` and `Setlist.fm ID` columns
+above). Free text before the header (a title, a description paragraph) and
+after the table (notes) is ignored by the parser in `lib/gig-history.mjs`;
+only lines starting with `|` after the header count as rows, and a row with
+the wrong number of columns is skipped.
+
+`Setlist.fm ID` is data only — the setlist.fm ID for the gig, where one
+exists. It is parsed into each gig object as `setlistfmId` but the app
+deliberately never reads that field: it has no `<th>`, isn't part of the
+`applyFilters`/search key lists, and isn't rendered in any row. Leave it
+blank for gigs that don't have one; adding a value never changes anything a
+visitor sees.
 
 ## How the embed works
 

--- a/content/GigTracker/gig-history.md
+++ b/content/GigTracker/gig-history.md
@@ -7,499 +7,499 @@ Data has been manually improved, validated and some gigs identified in gigs-miss
 
 **Most recent GIG in this file: 2026-06-27 — Hadestown: Teen Edition** — when updating this log, only fetch calendar events after this date.
 
-| Date | Show | Category | City | Country | Venue | Notes | Association |
-|---|---|---|---|---|---|---|---|
-| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | | |
-| 2026-06-23 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | | |
-| 2026-05-23 | Teen Jesus and the Jean Teasers, Ivy | Music | Wellington | New Zealand | San Fran | | |
-| 2026-05-01 | Fat Freddy's Drop | Music | Wellington | New Zealand | Michael Fowler Centre | | |
-| 2026-03-20 | The Datsuns, Warm Leather | Music | Wellington | New Zealand | San Fran | | |
-| 2026-03-01 | Werewolf | Theatre | Wellington | New Zealand | Circa Theatre | Starring Stella Reid, Joel Baxendale, Hannah Kelly | |
-| 2026-02-27 | Transvision Vamp, Dropper | Music | Wellington | New Zealand | Meow Nui | | |
-| 2026-02-06 | Jim Jefferies | Comedy | Wellington | New Zealand | Michael Fowler Centre | Son of a Carpenter | |
-| 2025-11-26 | Pixies, Elliot & Vincent | Music | Wellington | New Zealand | St James Theatre | | Frank Black |
-| 2025-11-22 | Beastwars, Soft Bait, Pull Down The Sun | Music | Wellington | New Zealand | Meow Nui | | |
-| 2025-10-21 | Commodores | Music | Wellington | New Zealand | St James Theatre | | |
-| 2025-10-10 | 2:22 A Ghost Story | Theatre | Wellington | New Zealand | Circa Theatre | Starring Pamela Sidhu, Regan Taylor, Serena Cotton, Jack Sergent-Shadbolt. Directed by Peter Feeney | |
-| 2025-08-19 | Mamma Mia | Theatre | Wellington | New Zealand | St James Theatre | Starring Gemma Hoskins, Rachel McSweeney. Directed by Maya Handa Naff | |
-| 2025-05-09 | The Addams Family: A New Musical | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Directed by Shelley Shackleton and Natalie Taiaki | |
-| 2025-03-23 | Kristin Hersh, Jon Muq | Music | Wellington | New Zealand | Old St Paul's | | |
-| 2025-03-16 | Shihad, The Boondocks | Music | Wellington | New Zealand | Meow Nui | | Jon Toogood |
-| 2025-02-02 | Kurtis Conner | Comedy | Wellington | New Zealand | The Opera House | The Goodfellow World Tour | |
-| 2024-12-29 | Shihad, Sublime, Home Brew, Ladyhawke, Elemeno P | Music | New Plymouth | New Zealand | Bowl of Brooklands | Rock The Bowl 2024 | Jon Toogood |
-| 2024-07-07 | Sense and Sensibility | Theatre | Wellington | New Zealand | Circa Theatre | Directed by Penny Ashton | |
-| 2024-02-25 | The National, The Beths | Music | Wellington | New Zealand | TSB Arena | | |
-| 2024-01-27 | Simple Minds, Texas, Collective Soul, Pseudo Echo | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2024 | |
-| 2023-12-07 | Come Together | Music | Wellington | New Zealand | St James Theatre | Big End of Year Bash 2023 | |
-| 2023-11-12 | Robbie Williams, Ladyhawke | Music | Napier | New Zealand | Mission Estate Winery | | |
-| 2023-03-18 | Shihad, Devilskin, Villainy, The Feelers, Racing, Che Fu | Music | Wellington | New Zealand | Waitangi Park | Jim Beam Homegrown 2023 | Jon Toogood |
-| 2023-02-04 | ZZ Top, Pat Benatar, Stone Temple Pilots, The Angels | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2023 | |
-| 2023-02-02 | Ed Sheeran, Kaylee Bell, Maisie Peters | Music | Wellington | New Zealand | Sky Stadium | | |
-| 2023-01-28 | Cowboy Junkies | Music | Wellington | New Zealand | The Opera House | | |
-| 2022-12-14 | Pixies, Anthonie Tonnon | Music | Wellington | New Zealand | The Opera House | | Frank Black |
-| 2022-12-08 | Guns N' Roses, Alien Weaponry, The Chats | Music | Wellington | New Zealand | Sky Stadium | | Duff McKagen, Slash |
-| 2022-11-24 | David Gray | Music | Wellington | New Zealand | TSB Arena | | |
-| 2022-10-22 | George Thorogood & The Destroyers | Music | Wellington | New Zealand | Michael Fowler Centre | | |
-| 2022-09-23 | The Beths | Music | Wellington | New Zealand | The Opera House | | |
-| 2022-08-20 | Reb Fountain, Jazmine Mary | Music | Wellington | New Zealand | The Opera House | | |
-| 2022-07-07 | Come Together | Music | Wellington | New Zealand | The Opera House | Fleetwood Mac - Rumours | |
-| 2022-07-02 | Hollie Smith | Music | Wellington | New Zealand | Meow | | |
-| 2022-06-25 | Teeks, NZ Symphony Orchestra | Music | Wellington | New Zealand | St James Theatre | Guest appearance by Hollie Smith | |
-| 2021-12-10 | Mel Parsons | Music | Wellington | New Zealand | Meow | | |
-| 2021-06-12 | The Nathan Haines Octet | Music | Wellington | New Zealand | The Opera House | | |
-| 2021-05-22 | Beastwars, Earth Tongue | Music | Wellington | New Zealand | The Hunter Lounge | | |
-| 2021-05-21 | Ben Elton | Comedy | Wellington | New Zealand | Michael Fowler Centre | Authentic Stupidity | |
-| 2021-04-03 | The Artist | Theatre | Wellington | New Zealand | Circa Theatre | | |
-| 2021-03-15 | Crowded House, Reb Fountain | Music | Wellington | New Zealand | TSB Arena | | Neil Finn |
-| 2020-11-25 | Come Together | Music | Wellington | New Zealand | The Opera House | Dire Straits' Brothers In Arms | |
-| 2020-11-21 | Shapeshifter, Tiki Taane | Music | Wellington | New Zealand | TSB Arena | | |
-| 2020-10-17 | Thomas Oliver | Music | Wellington | New Zealand | The Opera House | | |
-| 2020-10-09 | The Beths | Music | Wellington | New Zealand | San Fran | | |
-| 2020-10-03 | Whole Lotta Led | Music | Wellington | New Zealand | The Opera House | | |
-| 2020-03-07 | Beastwars, Uncle Acid and the Deadbeats, Witchskull, Earth Tongue | Music | Upper Hutt | New Zealand | Panhead Brewery | Obey the Riff | |
-| 2020-02-23 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Glass / Richter / Jarvi | |
-| 2020-02-05 | Queen + Adam Lambert | Music | Wellington | New Zealand | Sky Stadium | | |
-| 2020-01-25 | Billy Idol, George Thorogood, Anastasia, Smash Mouth | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2020 | |
-| 2019-09-16 | Fleetwood Mac | Music | Auckland | New Zealand | Spark Arena | | Neil Finn, Stevie Nicks |
-| 2019-07-24 | Hilltop Hoods, Jordan Lee | Music | Auckland | New Zealand | The Studio | | |
-| 2019-06-08 | Hollie Smith | Music | Wellington | New Zealand | The Thistle Inn | | |
-| 2019-06-05 | Herbie Hancock | Music | Wellington | New Zealand | Michael Fowler Centre | Wellington Jazz Festival 2019 | |
-| 2019-05-03 | Jordan Luck, Ekko Park | Music | Wellington | New Zealand | San Fran | | |
-| 2019-03-05 | The Jesus and Mary Chain, Shoddy | Music | Wellington | New Zealand | The Opera House | | |
-| 2019-03-02 | Eminem, Hilltop Hoods | Music | Wellington | New Zealand | Westpac Stadium | | |
-| 2019-02-23 | Trinity Roots, The Beths, C.W. Stoneking, The Miltones | Music | Paraparaumu | New Zealand | Southward's Car Museum | Coastella | |
-| 2019-02-06 | Jon Toogood | Music | Wellington | New Zealand | Meow | | |
-| 2018-11-26 | Whose Line Is It Anyway | Comedy | Wellington | New Zealand | The Opera House | Colin, Brad & Greg From Whose Line Is It Anyway? |
-| 2018-11-08 | Trinity Roots | Music | Wellington | New Zealand | The Opera House | | |
-| 2018-10-20 | Shihad, Beastwars, Villainy | Music | Wellington | New Zealand | Shed 6 | Shihad 30 | Jon Toogood |
-| 2018-10-13 | Don McGlashan | Music | Wellington | New Zealand | Old St Paul's | | |
-| 2018-09-13 | Chicago | Theatre | Wellington | New Zealand | The Opera House | Starring Carmen Pretorius, Samantha Peo, Jonathan Roxmouth. Directed by Walter Bobbie | |
-| 2018-07-13 | Beastwars, Earth Tongue, Slumbug | Music | Wellington | New Zealand | San Fran | | |
-| 2017-12-14 | Alt-J, Warpaint | Music | Wellington | New Zealand | TSB Arena | | |
-| 2017-09-14 | Hollie Smith, Mark Vanilau | Music | Wellington | New Zealand | San Fran | | |
-| 2017-07-09 | Rhys Darby | Comedy | Wellington | New Zealand | The Opera House | Mystic Time Bird | |
-| 2017-06-09 | Dianne Reeves | Music | Wellington | New Zealand | The Opera House | Wellington Jazz Festival 2017 | |
-| 2017-05-20 | Head Like A Hole, Hiboux | Music | Wellington | New Zealand | Valhalla | | |
-| 2017-05-05 | Thomas Oliver | Music | Auckland | New Zealand | The Tuning Fork | | |
-| 2017-04-28 | Ed Byrne | Comedy | Wellington | New Zealand | The Opera House | Outside Looking In | |
-| 2017-04-22 | The Darkness, Push Push | Music | Christchurch | New Zealand | The Foundry | | |
-| 2017-03-23 | Adele | Music | Auckland | New Zealand | Mount Smart Stadium | | |
-| 2017-03-10 | Pixies, Cut Off Your Hands | Music | Wellington | New Zealand | TSB Arena | | Frank Black |
-| 2017-02-05 | James Taylor | Music | Napier | New Zealand | Church Road Winery | | |
-| 2017-02-02 | Guns N' Roses, Wolfmother | Music | Wellington | New Zealand | Westpac Stadium | | Duff McKagen, Slash |
-| 2016-12-04 | Ben Harper, Miller Yule | Music | Wellington | New Zealand | Michael Fowler Centre | | |
-| 2016-12-03 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | The Planets | |
-| 2016-10-26 | Slipknot, Lamb of God | Music | Auckland | New Zealand | Vector Arena | | |
-| 2016-10-22 | Villainy | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2016-10-20 | Julianna Barwick | Music | Wellington | New Zealand | Caroline | | |
-| 2016-10-15 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Nutcracker | |
-| 2016-09-10 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Memory of an Angel | |
-| 2016-09-04 | Shaolin Warriors | Theatre | Wellington | New Zealand | St James Theatre | | |
-| 2016-07-16 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Capriccio | |
-| 2016-06-11 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Odes To Joy | |
-| 2016-05-07 | Jim Jefferies | Comedy | Wellington | New Zealand | The Opera House | | |
-| 2016-04-29 | Iron Maiden, The Raven Age | Music | Christchurch | New Zealand | Horncastle Arena | | |
-| 2016-04-22 | Beastwars, The Shocking, Stunning | Music | Wellington | New Zealand | San Fran | | |
-| 2016-04-08 | Hollie Smith | Music | Wellington | New Zealand | San Fran | | |
-| 2016-04-01 | Mick Fleetwood Blues, The Miltones | Music | Wellington | New Zealand | The Opera House | | |
-| 2016-02-26 | The Sword, American Sharks, Clowns | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2015-12-12 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Handel's Messiah | |
-| 2015-11-25 | Tame Impala, Silicon | Music | Wellington | New Zealand | Shed 6 | | |
-| 2015-11-21 | Elton John, Sol3 Mio | Music | Wellington | New Zealand | Westpac Stadium | | |
-| 2015-10-13 | Neil Finn | Music | Wellington | New Zealand | The Opera House | | |
-| 2015-10-02 | Devilskin, Villainy | Music | Wellington | New Zealand | San Fran | | |
-| 2015-09-19 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Classical Hits | |
-| 2015-08-31 | Dylan Moran | Comedy | Wellington | New Zealand | St James Theatre | We Got This | |
-| 2015-08-13 | Ahoribuzz | Music | Wellington | New Zealand | Meow | | Aaron Tokona |
-| 2015-06-12 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Wagner Gala | |
-| 2015-05-16 | New Zealand Opera, Orchestra Wellington | Opera | Wellington | New Zealand | St James Theatre | La Cenerentola (Cinderella) | |
-| 2015-06-04 | Dee Dee Bridgewater, Irvin Mayfield & The New Orleans Jazz Orchestra | Music | Wellington | New Zealand | The Opera House | | |
-| 2015-05-09 | Motley Crue, Alice Cooper | Music | Auckland | New Zealand | Vector Arena | The Final Tour | |
-| 2015-05-03 | Everclear | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2015-04-02 | Billy Idol, Cheap Trick, The Angels | Music | Wellington | New Zealand | TSB Arena | | |
-| 2015-03-29 | Gary Clark Jr, Aaron Tokona | Music | Wellington | New Zealand | Shed 6 | | |
-| 2015-03-01 | Slipknot, Marilyn Manson, Slash, Fall Out Boy, Judas Priest, The Smashing Pumpkins | Music | Sydney | Australia | Olympic Park | Soundwave Festival | |
-| 2015-02-18 | Slash, Devilskin | Music | Wellington | New Zealand | TSB Arena | | |
-| 2015-02-14 | Supergroove, Dave Dobbyn, Don McGlashan, Anika Moa | Music | Martinborough | New Zealand | Luna Estate | The Winery Tour 2015 | Che Fu |
-| 2015-01-24 | Heart, Foreigner, 3 Dog Night | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2015 | |
-| 2014-12-19 | The Datsuns | Music | Wellington | New Zealand | San Fran | | |
-| 2014-10-31 | Lorde | Music | Wellington | New Zealand | TSB Arena | | |
-| 2014-10-10 | Beastwars, Windhand, Mermaidens | Music | Wellington | New Zealand | San Fran | | |
-| 2014-09-30 | The Dire Straits Experience | Music | Wellington | New Zealand | Michael Fowler Centre | | |
-| 2014-09-19 | Boy and Bear, Mali Mali, Alexander Wildwood | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2014-08-28 | Kristin Hersh | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2014-08-08 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Mahler's 9th | |
-| 2014-06-13 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Beethoven's 4th & 5th | |
-| 2014-06-06 | Chick Corea, Gary Burton | Music | Wellington | New Zealand | Michael Fowler Centre | Duets | |
-| 2014-05-11 | Billy Connolly | Comedy | Wellington | New Zealand | TSB Arena | High Horse Tour | |
-| 2014-05-03 | Arctic Monkeys, Pond | Music | Wellington | New Zealand | TSB Arena | | |
-| 2014-04-27 | Steve Earle and the Dukes, The Mastersons | Music | Wellington | New Zealand | St James Theatre | | |
-| 2014-03-20 | Nine Inch Nails, Queens Of The Stone Age | Music | Wellington | New Zealand | TSB Arena | | |
-| 2014-03-14 | Kimbra, Arrested Development, Tim Finn, Pokey Lafarge | Music | New Plymouth | New Zealand | Bowl of Brooklands | WOMAD New Zealand | |
-| 2013-12-14 | Belinda Carlisle | Music | Wellington | New Zealand | The Opera House | | |
-| 2013-12-02 | Iris DeMent | Music | Wellington | New Zealand | Old St Paul's | | |
-| 2013-11-28 | Rules of Addiction | Music | Wellington | New Zealand | Bar Medusa | | |
-| 2013-10-05 | 8 Foot Sativa, Gunt, Bulletbelt, Gift of Ruin | Music | Wellington | New Zealand | Bar Medusa | | |
-| 2013-09-20 | Fat Freddy's Drop | Music | Wellington | New Zealand | The Opera House | Blackbird Album Release Tour | |
-| 2013-09-12 | The Datsuns, Milk Train | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2013-07-27 | Shapeshifter | Music | Wellington | New Zealand | Wellington Town Hall | Delta Live | |
-| 2013-05-05 | Tom Green | Comedy | Wellington | New Zealand | The Opera House | | |
-| 2013-05-04 | Unida, Beastwars | Music | Wellington | New Zealand | Bar Bodega | | |
-| 2013-03-19 | Neil Young and Crazy Horse, Husky, The Drones | Music | Wellington | New Zealand | TSB Arena | | Neil Young |
-| 2012-08-12 | Blur, New Order, The Specials | Music | London | United Kingdom | Hyde Park | BT London Live | |
-| 2012-08-01 | Ella Fitzgerald Experience | Music | London | United Kingdom | Ronnie Scott's Jazz Club | | |
-| 2012-07-28 | Eddie Vedder, Glen Hansard | Music | Manchester | United Kingdom | O2 Apollo | | |
-| 2012-07-27 | Hollie Smith | Music | London | United Kingdom | Vandella | | |
-| 2012-07-20 | Rhys Darby | Comedy | London | United Kingdom | Shepherd's Bush Empire | This Way to Spaceship | |
-| 2012-07-17 | Madonna, LMFAO, Martin Solveig | Music | London | United Kingdom | Hyde Park | MDNA Tour | |
-| 2012-07-14 | Bruce Springsteen, John Fogerty, Lady Antebellum, Amy Macdonald, Hey Monea! | Music | London | United Kingdom | Hyde Park | Hard Rock Calling. Guest appearances by Paul McCartney, John Fogerty, Tom Morello | |
-| 2012-07-13 | Soundgarden, Iggy & the Stooges, Cold Chisel, Black Stone Cherry | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | |
-| 2012-07-08 | Faith No More, Guano Padano | Music | London | United Kingdom | Hammersmith Apollo | Guest appearance by Danny DeVito | |
-| 2012-07-06 | Deadmau5, The Roots, Santigold, Childish Gambino, Metric | Music | London | United Kingdom | Hyde Park | Wireless Festival | |
-| 2012-06-26 | Robert Cray | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2012-06-20 | Tom Petty, Jonathan Wilson | Music | London | United Kingdom | Royal Albert Hall | | |
-| 2012-06-05 | Cypress Hill | Music | London | United Kingdom | The Forum | | |
-| 2012-06-02 | The Sunshine Boys | Theatre | London | United Kingdom | Savoy Theatre | Starring Danny DeVito, Richard Griffiths. Directed by Thea Sharrock | |
-| 2012-05-26 | Judas Priest, Saxon | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2012-05-03 | Jose Gonzalez, Tinariwen | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2012-04-30 | Russian Circles, Wovenhand | Music | London | United Kingdom | Scala | | |
-| 2012-03-25 | Korn, Downlink | Music | London | United Kingdom | Brixton Academy | | |
-| 2012-03-20 | The Phantom Of The Opera | Theatre | London | United Kingdom | Her Majesty's Theatre | Starring Peter Jöback, Sofia Escobar. Directed by Harold Prince | |
-| 2012-03-15 | Anthrax | Music | London | United Kingdom | Islington Academy | | |
-| 2012-02-26 | Imogen Heap, Ana Silvera | Music | London | United Kingdom | Roundhouse | | |
-| 2012-02-06 | Gilby Clarke, Badmouth | Music | London | United Kingdom | Underworld Camden | | |
-| 2012-01-29 | Throwing Needles | Music | London | United Kingdom | | | |
-| 2011-12-18 | The Royal Ballet | Other | London | United Kingdom | Royal Opera House | The Nutcracker | |
-| 2011-12-14 | Def Leppard, Motley Crue, Steel Panther | Music | London | United Kingdom | Wembley Arena | | |
-| 2011-11-26 | Dave Dobbyn | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2011-11-22 | Wye Oak | Music | London | United Kingdom | XOYO | | |
-| 2011-11-19 | Bob Dylan, Mark Knopfler | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2011-11-15 | Roxette, Darren Hayes | Music | London | United Kingdom | Wembley Arena | | |
-| 2011-11-02 | Throwing Muses, Spectrals | Music | London | United Kingdom | Shepherd's Bush Empire | | Kristin Hersh |
-| 2011-10-29 | Alice Cooper, New York Dolls, Arthur Brown | Music | London | United Kingdom | Alexandra Palace | Guest appearance by Lou Reed | |
-| 2011-10-27 | Lenny Kravitz | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2011-10-18 | Marketa Irglova | Music | London | United Kingdom | Bush Hall | | |
-| 2011-10-12 | Brett Anderson | Music | London | United Kingdom | KOKO | | |
-| 2011-10-01 | Von Hertzen Brothers | Music | London | United Kingdom | Borderline | | |
-| 2011-09-02 | Doug Stanhope | Comedy | London | United Kingdom | Leicester Square Theatre | | |
-| 2011-08-30 | Janes Addiction | Music | London | United Kingdom | KOKO | | |
-| 2011-08-24 | Deftones, Pulled Apart By Horses | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2011-08-13 | Throwing Needles | Music | London | United Kingdom | Punk (Soho) | | |
-| 2011-08-05 | Iron Maiden, DragonForce | Music | London | United Kingdom | The O2 Arena | | |
-| 2011-07-29 | Placido Domingo, Angela Gheorghiu | Opera | London | United Kingdom | The O2 Arena | | |
-| 2011-07-14 | Dylan Moran | Comedy | London | United Kingdom | Hammersmith Apollo | Yeah, Yeah | |
-| 2011-07-06 | Weezer | Music | London | United Kingdom | Brixton Academy | | |
-| 2011-06-30 | Cyndi Lauper, Charlie Musselwhite, Allen Toussaint | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2011-06-28 | BB King | Music | London | United Kingdom | Royal Albert Hall | Guest appearances by Slash, Ronnie Wood, Mick Hucknall, Derek Trucks, Susan Tedeschi | |
-| 2011-06-25 | Bon Jovi, Stevie Nicks, Ray Davies, Black Cards, Lissie, Vintage Trouble | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | |
-| 2011-06-21 | Ozzy Osbourne | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2011-06-18 | Simple Minds, James Walsh (Starsailor) | Music | Nottingham | United Kingdom | Sherwood Pines Park | Forest Live | |
-| 2011-06-11 | Yelawolf | Music | Amsterdam | The Netherlands | Melkweg Oude Zaal | | |
-| 2011-05-22 | The Straits | Music | London | United Kingdom | Royal Albert Hall | The Straits' debut public performance (charity show) | |
-| 2011-05-20 | The Naked And Famous | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2011-05-18 | Roger Waters | Music | London | United Kingdom | The O2 | | |
-| 2011-05-16 | Uncaged Monkeys | Other | London | United Kingdom | Hammersmith Apollo | Featuring Brian Cox, Ben Goldacre, Simon Singh, Robin Ince, Helen Arney | |
-| 2011-05-05 | Paloma Faith | Music | London | United Kingdom | Union Chapel | | |
-| 2011-04-11 | Jose Gonzalez, Gothenburg String Theory, Little Scream | Music | London | United Kingdom | Barbican Hall | | |
-| 2011-04-08 | Ed Byrne | Comedy | London | United Kingdom | Hammersmith Apollo | Crowd Pleaser | |
-| 2011-04-07 | Kylie Minogue, Ultra Girls | Music | London | United Kingdom | The O2 | | |
-| 2011-03-23 | Cage The Elephant | Music | London | United Kingdom | Electric Ballroom | | |
-| 2011-02-28 | Adler's Appetite | Music | London | United Kingdom | Underworld Camden | Guest appearance by Duff McKagan | |
-| 2011-02-25 | Foo Fighters, Cee Lo Green, Band Of Horses, No Age | Music | London | United Kingdom | Wembley Arena | NME Awards Big Gig 2011 | |
-| 2011-02-12 | Esben and the Witch | Music | Amsterdam | The Netherlands | Paradiso | | |
-| 2010-11-21 | Soulfly | Music | London | United Kingdom | KOKO | | |
-| 2010-11-19 | Therapy? | Music | London | United Kingdom | HMV Forum | | |
-| 2010-11-17 | Deftones, Coheed and Cambria | Music | London | United Kingdom | Brixton Academy | | |
-| 2010-11-11 | Linkin Park, Does It Offend You Yeah? | Music | London | United Kingdom | The O2 | | |
-| 2010-10-23 | Morcheeba | Music | London | United Kingdom | Roundhouse | | |
-| 2010-10-20 | Stephen Hawking | Other | London | United Kingdom | Royal Albert Hall | | |
-| 2010-10-13 | Guns N' Roses, Sebastian Bach | Music | London | United Kingdom | The O2 | | |
-| 2010-09-25 | Zodiac Mindwarp | Music | London | United Kingdom | Borderline | | |
-| 2010-07-24 | The Prodigy, Pendulum, Chase & Status, Enter Shikari | Music | Milton Keynes | United Kingdom | Milton Keynes Bowl | Warriors Dance Festival | |
-| 2010-07-22 | Sepultura, Gama Bomb | Music | London | United Kingdom | Scala | | |
-| 2010-07-17 | Penn & Teller | Comedy | London | United Kingdom | Hammersmith Apollo | | |
-| 2010-07-14 | Gil Scott-Heron | Music | London | United Kingdom | Somerset House | | |
-| 2010-06-29 | Melissa Etheridge | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2010-06-27 | Paul McCartney, Crowded House, Crosby Stills & Nash, Elvis Costello | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | Neil Finn |
-| 2010-06-04 | Pixies | Music | London | United Kingdom | Troxy | | Frank Black |
-| 2010-06-03 | Love Never Dies | Theatre | London | United Kingdom | Adelphi Theatre | Starring Ramin Karimloo, Sierra Boggess, Summer Strallen. Directed by Jack O'Brien | |
-| 2010-05-31 | Sunny Day Real Estate, Biffy Clyro | Music | London | United Kingdom | HMV Forum | | |
-| 2010-05-24 | Hope Sandoval, Dirt Blue Gene | Music | London | United Kingdom | Bush Hall | | |
-| 2010-05-04 | Belinda Carlisle | Music | London | United Kingdom | Jazz Cafe | | |
-| 2010-04-28 | Ricky Gervais | Comedy | London | United Kingdom | Wembley Arena | Science | |
-| 2010-04-23 | Rhod Gilbert | Comedy | London | United Kingdom | Hammersmith Apollo | The Cat That Looked like Nicholas Lyndhurst | | 
-| 2010-04-13 | Joe Perry Project | Music | London | United Kingdom | 100 Club | | |
-| 2010-04-01 | Airbourne, Black Spiders, Taking Dawn | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2010-02-20 | Depeche Mode, Nitzer Ebb | Music | London | United Kingdom | The O2 Arena | | |
-| 2009-12-19 | Nine Lessons and Carols for Godless People | Other | London | United Kingdom | UCL Bloomsbury | Featuring Brian Cox, Richard Dawkins, Ben Goldacre, Simon Singh, Johnny Ball, Mark Steel, Shappi Khorsandi, Josie Long, Richard Herring, Chris Addison, Al Murray, Robyn Hitchcock, the Mystery Fax Machine Chamber Orchestra, Gavin Osborn | |
-| 2009-12-10 | Marilyn Manson, Esoterica | Music | London | United Kingdom | Brixton Academy | | |
-| 2009-12-09 | Placebo, Silversun Pickups, The Horrors | Music | London | United Kingdom | The O2 Arena | | |
-| 2009-12-02 | W.A.S.P., The Glitterati | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2009-11-19 | Julian Clary | Comedy | London | United Kingdom | Leicester Square Theatre | | |
-| 2009-11-17 | Alice In Chains, Little Fish | Music | London | United Kingdom | HMV Forum | | |
-| 2009-11-12 | Biffy Clyro, Manchester Orchestra | Music | London | United Kingdom | Brixton Academy | | |
-| 2009-11-05 | Othello | Theatre | London | United Kingdom | Trafalgar Studios | Starring Lenny Henry, Conrad Nelson. Directed by Barrie Rutter | |
-| 2009-11-01 | Europe | Music | London | United Kingdom | Relentless Garage | | |
-| 2009-10-28 | ZZ Top, Steel Panther | Music | London | United Kingdom | Wembley Arena | | |
-| 2009-10-10 | The Cult, Aqua Nebula Oscillator | Music | London | United Kingdom | Royal Albert Hall | | |
-| 2009-10-07 | Pixies | Music | London | United Kingdom | Brixton Academy | | Frank Black |
-| 2009-09-24 | JTQ + The Ronnie Scott's All Stars | Music | London | United Kingdom | Ronnie Scott's Jazz Club | | James Taylor Quartet |
-| 2009-09-19 | Coldplay, Jay-Z, White Lies, Girls Aloud | Music | London | United Kingdom | Wembley Stadium | | |
-| 2009-09-17 | Massive Attack | Music | London | United Kingdom | Brixton Academy | | |
-| 2009-09-16 | Dame Kiri Te Kanawa | Opera | London | United Kingdom | The Tower of London | Continental Airlines Tower Festival | |
-| 2009-09-04 | Doug Stanhope | Comedy | London | United Kingdom | Leicester Square Theatre | | |
-| 2009-08-29 | Sasha & Digweed, David Guetta, Eric Prydz, Armin Van Buuren, Above & Beyond, Richie Hawtin | Music | London | United Kingdom | Clapham Common | South West Four (SW4) 2009 | |
-| 2009-08-27 | Deftones, Rival Schools | Music | London | United Kingdom | HMV Forum | | |
-| 2009-08-18 | Pearl Jam | Music | London | United Kingdom | The O2 Arena | | Eddie Vedder |
-| 2009-08-04 | Alice In Chains | Music | London | United Kingdom | Scala | | |
-| 2009-07-04 | Jeff Beck, Imelda May, Tal Wilkenfeld | Music | London | United Kingdom | Royal Albert Hall | Guest appearance by David Gilmour | |
-| 2009-06-28 | Bruce Springsteen, Dave Matthews Band, James Morrison, The Gaslight Anthem | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | |
-| 2009-06-27 | Neil Young, The Pretenders, Seasick Steve, Fleet Foxes, Ben Harper & Relentless7 | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | Ben Harper |
-| 2009-06-26 | AC/DC, The Answer, The Subways | Music | London | United Kingdom | Wembley Stadium | | |
-| 2009-06-25 | Chicken Foot, Skin | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2009-06-18 | Tesla | Music | London | United Kingdom | Islington Academy | | |
-| 2009-06-16 | Anthrax, Trigger the Bloodshed, Suicide Silence | Music | London | United Kingdom | ULU | | |
-| 2009-06-10 | Faith No More, Selfish Cunt | Music | London | United Kingdom | Brixton Academy | | |
-| 2009-06-06 | James Taylor Quartet | Music | London | United Kingdom | 100 Club | | |
-| 2009-06-03 | Waiting for Godot | Theatre | London | United Kingdom | Theatre Royal Haymarket | Starring Ian McKellen, Patrick Stewart, Simon Callow. Directed by Sean Mathias | |
-| 2009-05-05 | Therapy? | Music | London | United Kingdom | Islington Academy | | |
-| 2009-05-03 | Gary Moore | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2009-03-30 | Sinead O'Connor | Music | London | United Kingdom | The Pigalle Club | | |
-| 2009-03-28 | Metallica, Machine Head, The Sword | Music | London | United Kingdom | The O2 Arena | | |
-| 2009-03-13 | Oliver | Theatre | London | United Kingdom | Theatre Royal Drury Lane | Starring Rowan Atkinson, Jodie Prenger. Directed by Rupert Goold | |
-| 2009-02-21 | Judas Priest, Megadeth, Testament | Music | London | United Kingdom | Wembley Arena | | |
-| 2009-02-18 | The Datsuns | Music | London | United Kingdom | Underworld Camden | | |
-| 2008-12-21 | Nine Lessons and Carols for Godless People | Other | London | United Kingdom | Hammersmith Apollo | Featuring Richard Dawkins, Ben Goldacre, Simon Singh, Stewart Lee, Ricky Gervais, Josie Long, Tim Minchin, Richard Herring, Natalie Haynes, Chris Addison, Mark Thomas, Phil Jupitus, Dara Ó Briain, Jo Neary, Peter Buckley Hill, Jarvis Cocker, Robyn Hitchcock, Darren Hayman, Waen Shepherd, The Martin White Mini Fax Machine Orchestra, Gavin Osborn | Ricky Gervais |
-| 2008-12-17 | Biffy Clyro, Frightened Rabbit, People in Planes | Music | London | United Kingdom | Brixton Academy | | |
-| 2008-12-09 | Bill Bailey | Comedy | London | United Kingdom | Gielgud Theatre | Tinselworm | |
-| 2008-12-07 | Coldplay | Music | Glasgow | United Kingdom | SECC | | |
-| 2008-12-03 | Slipknot, Machine Head, Children of Bodom | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2008-11-24 | Dylan Moran | Comedy | London | United Kingdom | Hammersmith Apollo | What It Is | |
-| 2008-11-23 | Kristin Hersh | Music | London | United Kingdom | Borderline | | |
-| 2008-11-05 | Bryan Adams | Music | London | United Kingdom | The O2 | | |
-| 2008-10-25 | Cypress Hill | Music | London | United Kingdom | Battersea Power Station | Freeze Festival | |
-| 2008-10-24 | Aimee Mann, The Submarines | Music | London | United Kingdom | IndigO2 (The O2) | | |
-| 2008-10-16 | Spiritualized | Music | London | United Kingdom | Roundhouse | | |
-| 2008-10-01 | Seasick Steve, Amy LaVere | Music | London | United Kingdom | Royal Albert Hall | | |
-| 2008-09-30 | Brett Anderson, Kid Harpoon | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2008-09-27 | Supergroove | Music | London | United Kingdom | Olympia Grand Hall | | |
-| 2008-09-26 | LA Guns, Love/Hate | Music | London | United Kingdom | Islington Academy | | |
-| 2008-09-23 | Nigel Kennedy Quintet | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2008-09-18 | Duff McKagen | Music | London | United Kingdom | Islington Academy | | |
-| 2008-09-17 | Doug Stanhope | Comedy | London | United Kingdom | Arts Theatre | | |
-| 2008-09-16 | Riflemind | Theatre | London | United Kingdom | Trafalgar Studios | Starring John Hannah, Paul Hilton. Directed by Philip Seymour Hoffman | |
-| 2008-09-13 | Allanah Myles | Music | London | United Kingdom | Underworld Camden | | |
-| 2008-09-09 | The Datsuns | Music | London | United Kingdom | Barfly | | |
-| 2008-08-31 | Heaven and Hell, Motorhead, Judas Priest, Testament | Music | Mountain View | United States of America | Shoreline Ampitheatre | Metal Masters Tour | |
-| 2008-08-24 | Metallica, Tenacious D, Slipknot, Feeder, Avenged Sevenfold, Dropkick Murphys | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | |
-| 2008-08-23 | Carl Cox, Erick Morillo, John Digweed, Fedde Le Grand, Layo & Bushwacka!, Paolo Mojo | Music | London | United Kingdom | Clapham Common | South West Four (2008). Guest appearance by Danny Tenaglia | |
-| 2008-08-20 | Maceo Parker | Music | London | United Kingdom | The Pigalle Club | | |
-| 2008-08-13 | Lenny Kravitz, Sons of Albion | Music | London | United Kingdom | Brixton Academy | | |
-| 2008-07-31 | Billy Idol | Music | London | United Kingdom | Brixton Academy | | |
-| 2008-07-20 | Nigel Kennedy, BBC Concert Orchestra | Orchestra | London | United Kingdom | Royal Albert Hall | BBC Proms 2008 | |
-| 2008-07-19 | Jill Scott | Music | London | United Kingdom | Brixton Academy | | |
-| 2008-07-16 | Fat Pig | Theatre | London | United Kingdom | Trafalgar Studios | Starring Kris Marshall, Robert Webb. Directed by Neil LaBute | |
-| 2008-07-13 | The Year of Magical Thinking | Theatre | London | United Kingdom | National Theatre | Starring Vanessa Redgrave. Directed by David Hare | |
-| 2008-07-10 | The Frontline | Theatre | London | United Kingdom | Shakespeare's Globe | Starring Naana Agyei-Ampadu, Trystan Gravells. Directed by Matthew Dunster | |
-| 2008-07-05 | Iron Maiden, Avenged Sevenfold, Within Temptation, Lauren Harris | Music | London | United Kingdom | Twickenham Stadium | | |
-| 2008-07-03 | Duran Duran, The Duke Spirit, The Real People | Music | London | United Kingdom | The O2 | | |
-| 2008-06-28 | Eric Clapton, Sheryl Crow, John Mayer, Jason Mraz, Robert Randolph and The Family Band, Steve Boyce Band | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | |
-| 2008-06-27 | Bon Jovi, The Feeling, Ivy Rise | Music | London | United Kingdom | Twickenham Stadium | | |
-| 2008-06-26 | Def Leppard, Whitesnake, Black Stone Cherry | Music | London | United Kingdom | Wembley Arena | | |
-| 2008-06-25 | Radiohead | Music | London | United Kingdom | Victoria Park | | |
-| 2008-06-15 | Radiohead, Bat For Lashes | Music | Nimes | France | Arènes de Nîmes | | |
-| 2008-06-10 | The Herbaliser | Music | London | United Kingdom | 93 Feet East | | |
-| 2008-05-29 | We Will Rock You | Theatre | London | United Kingdom | Dominion Theatre | Directed by Christopher Renshaw | |
-| 2008-05-26 | Mark Knopfler, Bap Kennedy | Music | London | United Kingdom | Royal Albert Hall | | |
-| 2008-05-23 | Public Enemy, Dr Octagon (Kool Keith), Kutmasta Kurt, Edan, Anti Pop Consortium, MC Dagha | Music | London | United Kingdom | Brixton Academy | | |
-| 2008-05-17 | The Trailer Boat Ride | Music | London | United Kingdom | | | |
-| 2008-04-16 | The Breeders | Music | London | United Kingdom | KOKO | | |
-| 2008-04-14 | Hollie Smith | Music | London | United Kingdom | 12 Acklam Rd | | |
-| 2008-04-11 | Jose Gonzalez | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2008-04-10 | Portishead | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2008-04-09 | Black Crowes | Music | London | United Kingdom | Brixton Academy | | |
-| 2008-04-08 | English National Opera | Opera | London | United Kingdom | London Coliseum | David Lynch's Lost Highway | |
-| 2008-03-20 | The Cure, 65 Days of Static | Music | London | United Kingdom | Wembley Arena | | |
-| 2008-03-16 | Neil Young | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2008-03-07 | Apocolyptica | Music | London | United Kingdom | The Forum, Kentish Town | | |
-| 2008-02-29 | Speed-the-plow | Theatre | London | United Kingdom | The Old Vic | Starring Kevin Spacey, Jeff Goldblum, Laura Michelle Kelly. Directed by Matthew Warchus | |
-| 2008-02-24 | Tiesto, Ferry Corsten, Marco V, Sander van Doorn | Music | Utrecht | The Netherlands | Jaarbeurs (Trance Energy) | Trance Energy | |
-| 2008-02-16 | Ninja Tune, The Bug (Flowdan), Plastician, Ghislain Poirier, Bonobo, DJ Food, Coldcut (Jon More), zero dB, The Death Set, X Rabit | Music | London | United Kingdom | Electrowerkz | Ninja Tune presents You Don't Know | |
-| 2008-02-02 | Great White | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2007-12-13 | Chemical Bros, Simian Mobile Disco | Music | London | United Kingdom | Brixton Academy | | |
-| 2007-11-29 | Macbeth | Theatre | London | United Kingdom | Gielgud Theatre | Starring Patrick Stewart, Kate Fleetwood. Directed by Rupert Goold | |
-| 2007-11-28 | English National Opera | Opera | London | United Kingdom | London Coliseum | Aida | |
-| 2007-11-24 | Amy Winehouse | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2007-11-23 | The Hives | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2007-11-17 | Alice Cooper, Motorhead, Joan Jett | Music | London | United Kingdom | Wembley Arena | | |
-| 2007-11-16 | Gary Moore | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2007-11-14 | Sex Pistols | Music | London | United Kingdom | Brixton Academy | | |
-| 2007-11-10 | Heaven and Hell, Lamb of God, Iced Earth | Music | London | United Kingdom | Wembley Arena | | |
-| 2007-11-08 | Lez Zeppelin | Music | London | United Kingdom | Mean Fiddler | | |
-| 2007-11-05 | Tesla, Killing For Company | Music | London | United Kingdom | Islington Academy | | |
-| 2007-11-02 | W.A.S.P. | Music | London | United Kingdom | London Astoria | | |
-| 2007-10-23 | LCD Soundsystem | Music | London | United Kingdom | Brixton Academy | | |
-| 2007-10-18 | Underworld | Music | London | United Kingdom | Roundhouse | | |
-| 2007-10-11 | Turin Brakes | Music | London | United Kingdom | The Forum | | |
-| 2007-10-09 | Swimming with Sharks | Theatre | London | United Kingdom | Vaudeville Theatre | Starring Christian Slater, Matt Smith, Helen Baxendale. Directed by Wilson Milam | |
-| 2007-10-06 | Amp Fiddler | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2007-09-29 | Russell Brand | Comedy | London | United Kingdom | Hackney Empire | Only Joking | |
-| 2007-09-18 | Kosheen | Music | London | United Kingdom | KOKO | | |
-| 2007-09-07 | The Jesus and Mary Chain, The Horrors, Evan Dando | Music | London | United Kingdom | Brixton Academy | | |
-| 2007-09-06 | Beastie Boys | Music | London | United Kingdom | Roundhouse | | |
-| 2007-08-26 | The Smashing Pumpkins, Nine Inch Nails, Lostprophets, Fall Out Boy, Funeral for a Friend, The Used, Billy Talent | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | |
-| 2007-08-25 | Red Hot Chili Peppers, Arcade Fire, Bloc Party, Panic! At The Disco, Angels and Airwaves, Eagles of Death Metal, Paramore, Unkle, Biffy Clyro, The Shins, Dinosaur Jr | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | |
-| 2007-08-24 | Razorlight, Kings of Leon, Interpol, Maximo Park, Jimmy Eat World, Gossip, Gogol Bordello, Ash, Brand New | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | |
-| 2007-08-21 | Tool | Music | London | United Kingdom | Brixton Academy | | |
-| 2007-08-17 | Prince | Music | London | United Kingdom | The O2 Arena | 21 Nights in London: The Earth Tour | |
-| 2007-08-10 | BBC Concert Orchestra | Orchestra | London | United Kingdom | Royal Albert Hall | BBC Proms 36 | |
-| 2007-07-30 | Scorpions, Michael Schenker Group (MSG) | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2007-07-15 | Frank Black | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2007-07-14 | Bert Jansch, Beth Orton, Bernard Butler | Music | London | United Kingdom | Somerset House | | |
-| 2007-07-08 | Metallica, Machine Head, Mastodon, H.I.M. | Music | London | United Kingdom | Wembley Stadium | | |
-| 2007-07-07 | Madonna, Red Hot Chili Peppers, Genesis, Duran Duran, Metallica, Foo Fighters, Beastie Boys, Snow Patrol, Keane, Black Eyed Peas, John Legend, David Gray, Damien Rice, Corinne Bailey Rae, James Blunt, Kasabian, Bloc Party, Paolo Nutini, Pussycat Dolls | Music | London | United Kingdom | Wembley Stadium | Live Earth | |
-| 2007-07-06 | Seal | Music | London | United Kingdom | Tower of London | | |
-| 2007-07-04 | Tori Amos | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2007-06-28 | Tesla | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2007-06-27 | Fat Freddy's Drop | Music | London | United Kingdom | Astoria | | |
-| 2007-06-24 | Aerosmith, Chris Cornell, Jet, The Answer | Music | London | United Kingdom | Hyde Park | Hyde Park Calling | |
-| 2007-06-23 | Peter Gabriel, Crowded House, The Feeling, Ghosts | Music | London | United Kingdom | Hyde Park | Hyde Park Calling | Neil Finn |
-| 2007-06-22 | The Jesus and Mary Chain | Music | London | United Kingdom | Royal Festival Hall | Meltdown 2007 | |
-| 2007-06-17 | Muse, Biffy Clyro, My Chemical Romance | Music | London | United Kingdom | Wembley Stadium | | |
-| 2007-06-11 | Motley Crue | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2007-05-01 | Money Mark | Music | London | United Kingdom | ICA | | |
-| 2007-04-26 | Spiritualized | Music | London | United Kingdom | Shepherd's Bush Empire | Acoustic Mainlines | |
-| 2007-03-12 | Avenue Q | Theatre | London | United Kingdom | Noel Coward Theatre | Starring Luke Evans, Jon Robyns, Julie Atherton. Directed by Jason Moore | |
-| 2007-02-15 | Indigo Girls | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2007-02-08 | Massive Attack | Music | London | United Kingdom | Brixton Academy | | |
-| 2007-02-06 | Wolfmother | Music | London | United Kingdom | Hammersmith Apollo | | |
-| 2006-12-23 | Iron Maiden, Trivium, Lauren Harris | Music | London | United Kingdom | Earls Court | | |
-| 2006-12-03 | The Zutons | Music | London | United Kingdom | Roundhouse | | |
-| 2006-11-27 | Tool, Mastodon | Music | London | United Kingdom | Wembley Arena | | |
-| 2006-11-17 | W.A.S.P., Jaded | Music | London | United Kingdom | London Astoria | | |
-| 2006-11-12 | Bruce Springsteen | Music | London | United Kingdom | Wembley Arena | Guest appearance by Nils Lofgren | |
-| 2006-11-08 | The Datsuns | Music | London | United Kingdom | Electric Ballroom | | |
-| 2006-11-07 | INXS | Music | London | United Kingdom | Shepherd's Bush Empire | | |
-| 2006-10-21 | Salmonella Dub | Music | London | United Kingdom | Shepherd's Bush Empire | | Tiki Taane |
-| 2006-10-08 | Sander Kleinenberg, Mark Knight, Sebastien Leger, Martijn Ten Velden, Nick Bridges | Music | London | United Kingdom | Ministry of Sound | | |
-| 2006-09-16 | English National Opera | Opera | London | United Kingdom | Coliseum | Gaddafi: A Living Myth | |
-| 2006-09-12 | Pearl Jam, My Morning Jacket | Music | Paris | France | Palais Omnisports de Paris-Bercy | | Eddie Vedder |
-| 2006-08-26 | Sander Kleinenberg, Steve Lawler, Carl Cox, Paul Oakenfold, John Digweed, Pete Tong, Judge Jules, Seb Fontaine, Danny Howells, Fergie, The Shapeshifters, Mauro Picotto, Stanton Warriors, Nic Fanciulli, Sander van Doorn, Desyn Masiello, James Zabiela, Ian Betts, Matt Hardwick | Music | London | United Kingdom | Clapham Common | South West Four (SW4) 2006 | |
-| 2006-06-17 | Foo Fighters, Motorhead, Queens Of The Stone Age, Angels and Airwaves, Juliette & The Licks, The Subways | Music | London | United Kingdom | Hyde Park | Guest appearances by Lemmy, Brian May, Roger Taylor | |
-| 2004-12-27 | Tenacious D | Music | Wellington | New Zealand | St James Theatre | | |
-| 2004-12-17 | Cypress Hill | Music | Wellington | New Zealand | Starlight Ballroom | | |
-| 2003-04-24 | Morcheeba | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 2002-07-11 | The Breeders | Music | San Francisco | United States of America | The Fillmore | | |
-| 2002-07-05 | The Cranberries | Music | Los Angeles | United States of America | Greek Theatre | | |
-| 2002-04-19 | Tool | Music | Wellington | New Zealand | Queens Wharf Events Centre | | |
-| 2001-05-10 | Pantera | Music | Wellington | New Zealand | Queens Wharf Events Centre | | |
-| 2000-05-01 | ZZ Top | Music | Wellington | New Zealand | Queens Wharf Events Centre | | |
-| 1999-10-02 | Alanis Morissette | Music | Wellington | New Zealand | Queens Wharf Events Centre | | |
-| 1999-05-30 | Beastie Boys, DJ Mix Master Mike | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1999-04-17 | Keb' Mo', Paul Ubana Jones | Music | Wellington | New Zealand | State Opera House | | |
-| 1999-03-15 | Jaunt, The Whores Next Door, Pushkin | Music | Wellington | New Zealand | Indigo | | |
-| 1998-11-27 | Pushkin, The Whores Next Door, Broomdance | Music | Wellington | New Zealand | Indigo | | |
-| 1998-11-13 | Bongmaster, Hell Is Other People, Shihad | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood |
-| 1998-10-24 | Salvage, Whores Next Door, Wretched Skinny, Empty Quarter | Music | Wellington | New Zealand | Black Kat Cafe | | |
-| 1998-10-09 | The Living End, Brubeck | Music | Wellington | New Zealand | James Cabaret | | |
-| 1998-10-01 | Whores Next Door, Tau, Empty Quarter | Music | Wellington | New Zealand | Indigo | | |
-| 1998-09-25 | Whores, Empty Quarter, Wretched Skinny, Trawler, Big Blue Blanket | Music | Wellington | New Zealand | Black Kat Cafe | | |
-| 1998-09-18 | Fur Patrol, Weta | Music | Wellington | New Zealand | Indigo | | Aaron Tokona |
-| 1998-09-14 | Death In June | Music | Wellington | New Zealand | Indigo | | |
-| 1998-09-03 | The Whores Next Door, Lamps, Pushkats | Music | Wellington | New Zealand | Indigo | | |
-| 1998-08-21 | The Whores Next Door, Empty Quarter | Music | Wellington | New Zealand | Black Kat Cafe | | |
-| 1998-08-19 | The Whores Next Door, Trinity, Salvage | Music | Wellington | New Zealand | Victoria University of Wellington | Battle of the Bands | |
-| 1998-07-25 | Alex Paterson, Coda | Music | Wellington | New Zealand | Escape | | |
-| 1998-06-13 | Whores Next Door, Wretched Skinny | Music | Wellington | New Zealand | Black Kat Cafe | | |
-| 1998-04-09 | Breathe, The Stereo Bus, Tim Finn, DLT & Che Fu, Head Like A Hole | Music | Wellington | New Zealand | Wellington Town Hall | | DLT, Che Fu |
-| 1998-04-08 | Portishead | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1998-03-10 | Cassandra Wilson | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1998-02-19 | Foo Fighters, Weta | Music | Wellington | New Zealand | Wellington Town Hall | | Aaron Tokona |
-| 1998-01-29 | Radiohead | Music | Wellington | New Zealand | Queens Wharf Events Centre | | |
-| 1997-10-03 | Bike, Breakfast of Champions | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1997-07-05 | Faith No More, Better Than Ezra, The Nixons, Orbit, Muse | Music | Fort Lauderdale | United States of America | Markham Park | Zetafest | |
-| 1997-04-05 | Head Like A Hole | Music | Wellington | New Zealand | Civic Square | | |
-| 1997-03-13 | Baconfoot, Snitches, Gas Huffer | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1997-03-07 | Head Like A Hole, Frenzal Rhomb | Music | Wellington | New Zealand | Union Hall | | |
-| 1997-03-05 | Superette | Music | Wellington | New Zealand | Union Hall | | |
-| 1997-03-04 | David Harrow, Salmonella Dub | Music | Wellington | New Zealand | Union Hall | | Tiki Taane |
-| 1997-02-22 | ENZSO | Music | Upper Hutt | New Zealand | Trentham Memorial Park | Featuring Split Enz / NZ Symphony Orchestra | Neil Finn, Tim Finn, NZ Symphony Orchestra |
-| 1997-02-21 | Letterbox Lambs, Superette | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1997-01-22 | The Exponents, Pash | Music | Wellington | New Zealand | James Cabaret | | Jordan Luck |
-| 1997-01-16 | Soundgarden, Weta | Music | Wellington | New Zealand | Wellington Town Hall | | Aaron Tokona |
-| 1997-01-05 | Weta, Breathe, Short | Music | Wellington | New Zealand | Civic Square | | Aaron Tokona |
-| 1996-12-18 | The Warners | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1996-05-10 | Shihad | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood |
-| 1996-05-04 | Red Hot Chilli Peppers, Thorazine Shuffle | Music | Wellington | New Zealand | Queens Wharf Events Centre | | |
-| 1996-04-10 | Atomic Blossom | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1996-01-19 | Skwish | Music | Wellington | New Zealand | | | |
-| 1996-01-11 | Knightshade, Dave Dobbyn, Muttonbirds, Joe Satriani, Stranglers, The Cruel Sea, Mental As Anything, The Exponents, Barry Saunders, Head Like A Hole, Pumpkinhead | Music | Woodville | New Zealand | Airlie Brae | Mountain Rock 5 | Don McGlashan, Jordan Luck |
-| 1995-10-01 | Skwish | Music | Wellington | New Zealand | Cuba Cuba | | |
-| 1995-08-11 | Shihad, Short | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood |
-| 1995-08-05 | Faith No More, Pumpkinhead, Dead Flowers | Music | Wellington | New Zealand | Wellington Show + Sports Centre | | |
-| 1995-08-04 | Letterbox Lambs, Breathe | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1995-08-02 | Condition Red | Music | Wellington | New Zealand | Antipodes | | |
-| 1995-07-31 | Dave Dobbyn, Emma Paki | Music | Wellington | New Zealand | James Cabaret | | |
-| 1995-05-25 | Sweet Family Unit | Music | Wellington | New Zealand | Antipodes | | |
-| 1995-04-01 | Squirm | Music | Wellington | New Zealand | Antipodes | | |
-| 1995-01-19 | The Cult, Fat Mannequin | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1995-01-14 | No Thrills, Head Like A Hole, Greg Johnson, Yothu Yindi, The Exponents, Tama Renata, Upper Hutt Posse, Brainchilds, Muttonbirds, Supergroove, Midnight Oil, Dave Dobbyn, Tim Finn, Semi Lemon Kola | Music | Woodville | New Zealand | | Mountain Rock IV | Che Fu, DLT, Don McGlashan, Jordan Luck |
-| 1994-12-22 | Stonor, Nefretete, Wormhole, Rollie Stones | Music | Lower Hutt | New Zealand | Lucky Jacks | | |
-| 1994-12-17 | Stonor | Music | Grenada North | New Zealand | Warehouse | | |
-| 1994-12-09 | Slink Patrol, Skwish, Stonor | Music | Wellington | New Zealand | Thistle Hall | | |
-| 1994-11-30 | Tori Amos, Ted Brown | Music | Auckland | New Zealand | Auckland Town Hall | | |
-| 1994-11-26 | Stonor | Music | Lower Hutt | New Zealand | Miller Bar | | |
-| 1994-11-18 | Stonor | Music | Wellington | New Zealand | 38 Norway St | | |
-| 1994-11-06 | Pantera, Fat Mannequin | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1994-11-02 | Skwish, Plankton | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1994-10-05 | Beastie Boys, Helmet, Emulsifier | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1994-08-27 | Supergroove, Nixons, MCOJ & DLT | Music | Wellington | New Zealand | James Cabaret | | Che Fu |
-| 1994-08-04 | Skwish | Music | Wellington | New Zealand | Bar Bodega | | |
-| 1994-07-23 | Supergroove, Thorazine Shuffle, DLT | Music | Wellington | New Zealand | James Cabaret | | Che Fu |
-| 1994-07-01 | Head Like A Hole, Monster | Music | Wellington | New Zealand | Union Hall | | |
-| 1994-06-23 | Kristin Hersh, Brainchilds | Music | Wellington | New Zealand | Paramount Theatre | | |
-| 1994-05-27 | Burning Roses, The Crystalline | Music | Wellington | New Zealand | Union Building, Victoria University | | |
-| 1994-05-21 | Desert Road | Music | Wellington | New Zealand | Metro | | |
-| 1994-04-27 | Muttonbirds, Emma Paki, Bilge Festival | Music | Wellington | New Zealand | James Cabaret | | Don McGlashan |
-| 1994-03-01 | The 3Ds, Bailter Space, Solid Gold Hell | Music | Wellington | New Zealand | Union Hall | | |
-| 1994-02-27 | JPSE, Cinematic | Music | Wellington | New Zealand | Union Hall | | |
-| 1994-02-25 | Crowded House, Dave Dobbyn, Annie Crummer | Music | Wellington | New Zealand | Wellington Town Hall | Freedom | Neil Finn |
-| 1994-02-05 | Soundgarden, The Smashing Pumpkins, Shihad, Head Like A Hole, Muttonbirds, JPSE, The Breeders, Urge Overkill, Hard-Ons, Jan Hellriegel, Cruel Sea, Kid Eternity | Music | Auckland | New Zealand | Mount Smart Stadium | Big Day Out | Jon Toogood, Don McGlashan |
-| 1994-02-04 | Boney M | Music | Hamilton | New Zealand | Hamilton Domain | | |
-| 1994-01-15 | Supergroove, Andrew Fagan, The Warratahs, R. Bryant, K Borich, Hello Sailor, Jan Hellriegel, Dave Dobbyn, Shona Laing, Straitjacket Fits, Desert Road, The Exponents, Drawn, Wildfire, Shihad, Head Like A Hole, Dead Flowers | Music | Woodville | New Zealand | | Mountain Rock III | Barry Saunders, Che Fu, Jon Toogood, Jordan Luck |
-| 1994-01-14 | Dave Dobbyn, The Exponents | Music | Wellington | New Zealand | James Cabaret | | Jordan Luck |
-| 1993-12-17 | Premature Autopsy, Loves Ugly Children, Head Like A Hole, Shihad | Music | Wellington | New Zealand | Union Hall | | Jon Toogood |
-| 1993-11-18 | Karnage, Warpspasm, Carcass | Music | Wellington | New Zealand | Stox | | |
-| 1993-09-16 | Glass Candle Grenade, Wake | Music | Wellington | New Zealand | Kaminskys | | |
-| 1993-09-12 | Living Colour, Big Deal | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1993-08-15 | Wellington Youth Choir, Manawatu Youth Choir | Music | Wellington | New Zealand | | | |
-| 1993-07-28 | Pungent Stench, Tension, Warp Drive | Music | Wellington | New Zealand | Kaminskys | | |
-| 1993-07-23 | Shihad, Skinshed, Flail | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood |
-| 1993-07-02 | Head Like A Hole, Steak, Funkmutha | Music | Wellington | New Zealand | Stox | | |
-| 1993-05-22 | Push Push, The Spirals | Music | Wellington | New Zealand | Show & Sports Centre | | |
-| 1993-05-13 | Faith No More, Emulsifier | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1993-04-23 | JPSE | Music | Wellington | New Zealand | Sol Bar | | |
-| 1993-04-17 | Dead Flowers, Andrew Fagan, Big Deal, Ugly Truth, Open Oyster, Wildfire | Music | Wellington | New Zealand | Shed 11 | | |
-| 1993-04-03 | Shihad, Conventional Toasters, Funkmutha | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood |
-| 1993-03-04 | JPSE, Muttonbirds | Music | Wellington | New Zealand | Union Hall | | Don McGlashan |
-| 1993-03-02 | The Lemonheads, David Kilgour, Bilge Festival | Music | Wellington | New Zealand | Union Hall | | Evan Dando |
-| 1993-02-25 | Billy Connolly | Comedy | Wellington | New Zealand | Michael Fowler Centre | | |
-| 1993-02-06 | Guns N' Roses, Skid Row, Dead Flowers | Music | Auckland | New Zealand | Mount Smart Stadium | | Duff McKagen, Gilby Clarke, Sebastian Bach, Slash |
-| 1993-01-16 | Shona Laing, Sam Hunt, Push Push, Shihad, Muttonbirds, Ted Clarke, Jan Hellriegel, Desert Road, Nine Livez, Dead Flowers, Southside of Bombay, Big Deal, Blue Buffoons, Flippin Hippies, Savana, Johnny B Band, Out of the Blue, Snowline | Music | Woodville | New Zealand | Airlie Brae | Mountain Rock II | Don McGlashan, Jon Toogood |
-| 1993-01-11 | Jenny Morris, JPSE | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1993-01-02 | Archies Aunts, Charlotte Sometimes, Shona Laing,  Merenia | Music | Wellington | New Zealand | Civic Square | | |
-| 1992-12-10 | Malchicks, The Exponents | Music | Wellington | New Zealand | James Cabaret | | Jordan Luck |
-| 1992-11-08 | Still, Kamikaze Daydream | Music | Wellington | New Zealand | Dragons | | |
-| 1992-08-13 | The Cure, Jan Hellriegel | Music | Wellington | New Zealand | Wellington Town Hall | | |
-| 1992-05-17 | Scarf | Music | Hastings | New Zealand | Club Ew-els | | |
-| 1992-04-16 | Braintree, Shihad | Music | Wellington | New Zealand | New Carpark | | Jon Toogood |
-| 1992-04-03 | Buddakhan, The Exponents | Music | Wellington | New Zealand | New Carpark | | Jordan Luck |
-| 1992-03-07 | Scios, Slaine, Sacrament, Deliverance, Vas Deferens | Music | Wellington | New Zealand | New Carpark | | |
-| 1992-01-25 | Midge Marsden, Push Push, Dick Thrust, Shihad, Desert Road, Southside of Bombay, Lets Planet, Big Deal, Thin Fish, Head Like A Hole, Ralph Bennett, Dave Murphy, Luke Hurcey, Johnny B Band, Wild Fire, Serpentine, Bullfrog Rata, Blue Smoke, Sam Hunt, Vandrix, Helter Skelter | Music | Woodville | New Zealand | | Mountain Rock | Jon Toogood |
-| 1992-01-24 | Buddakhan | Music | Wellington | New Zealand | New Carpark | | |
-| 1992-01-01 | Push Push, The Exponents | Music | Napier | New Zealand | Onekawa Rockgarden | | Jordan Luck |
-| 1991-12-28 | Ted Clarke, Backdoor Blues | Music | Hastings | New Zealand | Stortford Lodge | | |
-| 1991-11-14 | Shihad, AC/DC | Music | Wellington | New Zealand | Athletic Park | | Jon Toogood |
-| 1991-09-27 | Scios, NIHL, Sacrament, Josephine Bewitched, Deliverance | Music | Wellington | New Zealand | Empire Warehouse | | |
-| 1991-04-10 | Jeff Healey, Midge Marsden | Music | Wellington | New Zealand | St James Theatre | | |
-| 1986-03-04 | Dire Straits, Satellite Spies | Music | Wellington | New Zealand | Athletic Park | | Mark Knopfler |
+| Date | Show | Category | City | Country | Venue | Notes | Association | Setlist.fm ID |
+|---|---|---|---|---|---|---|---|---|
+| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | | | |
+| 2026-06-23 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | | | |
+| 2026-05-23 | Teen Jesus and the Jean Teasers, Ivy | Music | Wellington | New Zealand | San Fran | | | |
+| 2026-05-01 | Fat Freddy's Drop | Music | Wellington | New Zealand | Michael Fowler Centre | | | |
+| 2026-03-20 | The Datsuns, Warm Leather | Music | Wellington | New Zealand | San Fran | | | |
+| 2026-03-01 | Werewolf | Theatre | Wellington | New Zealand | Circa Theatre | Starring Stella Reid, Joel Baxendale, Hannah Kelly | | |
+| 2026-02-27 | Transvision Vamp, Dropper | Music | Wellington | New Zealand | Meow Nui | | | |
+| 2026-02-06 | Jim Jefferies | Comedy | Wellington | New Zealand | Michael Fowler Centre | Son of a Carpenter | | |
+| 2025-11-26 | Pixies, Elliot & Vincent | Music | Wellington | New Zealand | St James Theatre | | Frank Black | |
+| 2025-11-22 | Beastwars, Soft Bait, Pull Down The Sun | Music | Wellington | New Zealand | Meow Nui | | | |
+| 2025-10-21 | Commodores | Music | Wellington | New Zealand | St James Theatre | | | |
+| 2025-10-10 | 2:22 A Ghost Story | Theatre | Wellington | New Zealand | Circa Theatre | Starring Pamela Sidhu, Regan Taylor, Serena Cotton, Jack Sergent-Shadbolt. Directed by Peter Feeney | | |
+| 2025-08-19 | Mamma Mia | Theatre | Wellington | New Zealand | St James Theatre | Starring Gemma Hoskins, Rachel McSweeney. Directed by Maya Handa Naff | | |
+| 2025-05-09 | The Addams Family: A New Musical | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Directed by Shelley Shackleton and Natalie Taiaki | | |
+| 2025-03-23 | Kristin Hersh, Jon Muq | Music | Wellington | New Zealand | Old St Paul's | | | |
+| 2025-03-16 | Shihad, The Boondocks | Music | Wellington | New Zealand | Meow Nui | | Jon Toogood | |
+| 2025-02-02 | Kurtis Conner | Comedy | Wellington | New Zealand | The Opera House | The Goodfellow World Tour | | |
+| 2024-12-29 | Shihad, Sublime, Home Brew, Ladyhawke, Elemeno P | Music | New Plymouth | New Zealand | Bowl of Brooklands | Rock The Bowl 2024 | Jon Toogood | |
+| 2024-07-07 | Sense and Sensibility | Theatre | Wellington | New Zealand | Circa Theatre | Directed by Penny Ashton | | |
+| 2024-02-25 | The National, The Beths | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2024-01-27 | Simple Minds, Texas, Collective Soul, Pseudo Echo | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2024 | | |
+| 2023-12-07 | Come Together | Music | Wellington | New Zealand | St James Theatre | Big End of Year Bash 2023 | | |
+| 2023-11-12 | Robbie Williams, Ladyhawke | Music | Napier | New Zealand | Mission Estate Winery | | | |
+| 2023-03-18 | Shihad, Devilskin, Villainy, The Feelers, Racing, Che Fu | Music | Wellington | New Zealand | Waitangi Park | Jim Beam Homegrown 2023 | Jon Toogood | |
+| 2023-02-04 | ZZ Top, Pat Benatar, Stone Temple Pilots, The Angels | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2023 | | |
+| 2023-02-02 | Ed Sheeran, Kaylee Bell, Maisie Peters | Music | Wellington | New Zealand | Sky Stadium | | | |
+| 2023-01-28 | Cowboy Junkies | Music | Wellington | New Zealand | The Opera House | | | |
+| 2022-12-14 | Pixies, Anthonie Tonnon | Music | Wellington | New Zealand | The Opera House | | Frank Black | |
+| 2022-12-08 | Guns N' Roses, Alien Weaponry, The Chats | Music | Wellington | New Zealand | Sky Stadium | | Duff McKagen, Slash | |
+| 2022-11-24 | David Gray | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2022-10-22 | George Thorogood & The Destroyers | Music | Wellington | New Zealand | Michael Fowler Centre | | | |
+| 2022-09-23 | The Beths | Music | Wellington | New Zealand | The Opera House | | | |
+| 2022-08-20 | Reb Fountain, Jazmine Mary | Music | Wellington | New Zealand | The Opera House | | | |
+| 2022-07-07 | Come Together | Music | Wellington | New Zealand | The Opera House | Fleetwood Mac - Rumours | | |
+| 2022-07-02 | Hollie Smith | Music | Wellington | New Zealand | Meow | | | |
+| 2022-06-25 | Teeks, NZ Symphony Orchestra | Music | Wellington | New Zealand | St James Theatre | Guest appearance by Hollie Smith | | |
+| 2021-12-10 | Mel Parsons | Music | Wellington | New Zealand | Meow | | | |
+| 2021-06-12 | The Nathan Haines Octet | Music | Wellington | New Zealand | The Opera House | | | |
+| 2021-05-22 | Beastwars, Earth Tongue | Music | Wellington | New Zealand | The Hunter Lounge | | | |
+| 2021-05-21 | Ben Elton | Comedy | Wellington | New Zealand | Michael Fowler Centre | Authentic Stupidity | | |
+| 2021-04-03 | The Artist | Theatre | Wellington | New Zealand | Circa Theatre | | | |
+| 2021-03-15 | Crowded House, Reb Fountain | Music | Wellington | New Zealand | TSB Arena | | Neil Finn | |
+| 2020-11-25 | Come Together | Music | Wellington | New Zealand | The Opera House | Dire Straits' Brothers In Arms | | |
+| 2020-11-21 | Shapeshifter, Tiki Taane | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2020-10-17 | Thomas Oliver | Music | Wellington | New Zealand | The Opera House | | | |
+| 2020-10-09 | The Beths | Music | Wellington | New Zealand | San Fran | | | |
+| 2020-10-03 | Whole Lotta Led | Music | Wellington | New Zealand | The Opera House | | | |
+| 2020-03-07 | Beastwars, Uncle Acid and the Deadbeats, Witchskull, Earth Tongue | Music | Upper Hutt | New Zealand | Panhead Brewery | Obey the Riff | | |
+| 2020-02-23 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Glass / Richter / Jarvi | | |
+| 2020-02-05 | Queen + Adam Lambert | Music | Wellington | New Zealand | Sky Stadium | | | |
+| 2020-01-25 | Billy Idol, George Thorogood, Anastasia, Smash Mouth | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2020 | | |
+| 2019-09-16 | Fleetwood Mac | Music | Auckland | New Zealand | Spark Arena | | Neil Finn, Stevie Nicks | |
+| 2019-07-24 | Hilltop Hoods, Jordan Lee | Music | Auckland | New Zealand | The Studio | | | |
+| 2019-06-08 | Hollie Smith | Music | Wellington | New Zealand | The Thistle Inn | | | |
+| 2019-06-05 | Herbie Hancock | Music | Wellington | New Zealand | Michael Fowler Centre | Wellington Jazz Festival 2019 | | |
+| 2019-05-03 | Jordan Luck, Ekko Park | Music | Wellington | New Zealand | San Fran | | | |
+| 2019-03-05 | The Jesus and Mary Chain, Shoddy | Music | Wellington | New Zealand | The Opera House | | | |
+| 2019-03-02 | Eminem, Hilltop Hoods | Music | Wellington | New Zealand | Westpac Stadium | | | |
+| 2019-02-23 | Trinity Roots, The Beths, C.W. Stoneking, The Miltones | Music | Paraparaumu | New Zealand | Southward's Car Museum | Coastella | | |
+| 2019-02-06 | Jon Toogood | Music | Wellington | New Zealand | Meow | | | |
+| 2018-11-26 | Whose Line Is It Anyway | Comedy | Wellington | New Zealand | The Opera House | Colin, Brad & Greg From Whose Line Is It Anyway? | |
+| 2018-11-08 | Trinity Roots | Music | Wellington | New Zealand | The Opera House | | | |
+| 2018-10-20 | Shihad, Beastwars, Villainy | Music | Wellington | New Zealand | Shed 6 | Shihad 30 | Jon Toogood | |
+| 2018-10-13 | Don McGlashan | Music | Wellington | New Zealand | Old St Paul's | | | |
+| 2018-09-13 | Chicago | Theatre | Wellington | New Zealand | The Opera House | Starring Carmen Pretorius, Samantha Peo, Jonathan Roxmouth. Directed by Walter Bobbie | | |
+| 2018-07-13 | Beastwars, Earth Tongue, Slumbug | Music | Wellington | New Zealand | San Fran | | | |
+| 2017-12-14 | Alt-J, Warpaint | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2017-09-14 | Hollie Smith, Mark Vanilau | Music | Wellington | New Zealand | San Fran | | | |
+| 2017-07-09 | Rhys Darby | Comedy | Wellington | New Zealand | The Opera House | Mystic Time Bird | | |
+| 2017-06-09 | Dianne Reeves | Music | Wellington | New Zealand | The Opera House | Wellington Jazz Festival 2017 | | |
+| 2017-05-20 | Head Like A Hole, Hiboux | Music | Wellington | New Zealand | Valhalla | | | |
+| 2017-05-05 | Thomas Oliver | Music | Auckland | New Zealand | The Tuning Fork | | | |
+| 2017-04-28 | Ed Byrne | Comedy | Wellington | New Zealand | The Opera House | Outside Looking In | | |
+| 2017-04-22 | The Darkness, Push Push | Music | Christchurch | New Zealand | The Foundry | | | |
+| 2017-03-23 | Adele | Music | Auckland | New Zealand | Mount Smart Stadium | | | |
+| 2017-03-10 | Pixies, Cut Off Your Hands | Music | Wellington | New Zealand | TSB Arena | | Frank Black | |
+| 2017-02-05 | James Taylor | Music | Napier | New Zealand | Church Road Winery | | | |
+| 2017-02-02 | Guns N' Roses, Wolfmother | Music | Wellington | New Zealand | Westpac Stadium | | Duff McKagen, Slash | |
+| 2016-12-04 | Ben Harper, Miller Yule | Music | Wellington | New Zealand | Michael Fowler Centre | | | |
+| 2016-12-03 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | The Planets | | |
+| 2016-10-26 | Slipknot, Lamb of God | Music | Auckland | New Zealand | Vector Arena | | | |
+| 2016-10-22 | Villainy | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2016-10-20 | Julianna Barwick | Music | Wellington | New Zealand | Caroline | | | |
+| 2016-10-15 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Nutcracker | | |
+| 2016-09-10 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Memory of an Angel | | |
+| 2016-09-04 | Shaolin Warriors | Theatre | Wellington | New Zealand | St James Theatre | | | |
+| 2016-07-16 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Capriccio | | |
+| 2016-06-11 | Orchestra Wellington | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Odes To Joy | | |
+| 2016-05-07 | Jim Jefferies | Comedy | Wellington | New Zealand | The Opera House | | | |
+| 2016-04-29 | Iron Maiden, The Raven Age | Music | Christchurch | New Zealand | Horncastle Arena | | | |
+| 2016-04-22 | Beastwars, The Shocking, Stunning | Music | Wellington | New Zealand | San Fran | | | |
+| 2016-04-08 | Hollie Smith | Music | Wellington | New Zealand | San Fran | | | |
+| 2016-04-01 | Mick Fleetwood Blues, The Miltones | Music | Wellington | New Zealand | The Opera House | | | |
+| 2016-02-26 | The Sword, American Sharks, Clowns | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2015-12-12 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Handel's Messiah | | |
+| 2015-11-25 | Tame Impala, Silicon | Music | Wellington | New Zealand | Shed 6 | | | |
+| 2015-11-21 | Elton John, Sol3 Mio | Music | Wellington | New Zealand | Westpac Stadium | | | |
+| 2015-10-13 | Neil Finn | Music | Wellington | New Zealand | The Opera House | | | |
+| 2015-10-02 | Devilskin, Villainy | Music | Wellington | New Zealand | San Fran | | | |
+| 2015-09-19 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Classical Hits | | |
+| 2015-08-31 | Dylan Moran | Comedy | Wellington | New Zealand | St James Theatre | We Got This | | |
+| 2015-08-13 | Ahoribuzz | Music | Wellington | New Zealand | Meow | | Aaron Tokona | |
+| 2015-06-12 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Wagner Gala | | |
+| 2015-05-16 | New Zealand Opera, Orchestra Wellington | Opera | Wellington | New Zealand | St James Theatre | La Cenerentola (Cinderella) | | |
+| 2015-06-04 | Dee Dee Bridgewater, Irvin Mayfield & The New Orleans Jazz Orchestra | Music | Wellington | New Zealand | The Opera House | | | |
+| 2015-05-09 | Motley Crue, Alice Cooper | Music | Auckland | New Zealand | Vector Arena | The Final Tour | | |
+| 2015-05-03 | Everclear | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2015-04-02 | Billy Idol, Cheap Trick, The Angels | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2015-03-29 | Gary Clark Jr, Aaron Tokona | Music | Wellington | New Zealand | Shed 6 | | | |
+| 2015-03-01 | Slipknot, Marilyn Manson, Slash, Fall Out Boy, Judas Priest, The Smashing Pumpkins | Music | Sydney | Australia | Olympic Park | Soundwave Festival | | |
+| 2015-02-18 | Slash, Devilskin | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2015-02-14 | Supergroove, Dave Dobbyn, Don McGlashan, Anika Moa | Music | Martinborough | New Zealand | Luna Estate | The Winery Tour 2015 | Che Fu | |
+| 2015-01-24 | Heart, Foreigner, 3 Dog Night | Music | Taupo | New Zealand | Taupo Amphitheatre | Summer Concert Tour 2015 | | |
+| 2014-12-19 | The Datsuns | Music | Wellington | New Zealand | San Fran | | | |
+| 2014-10-31 | Lorde | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2014-10-10 | Beastwars, Windhand, Mermaidens | Music | Wellington | New Zealand | San Fran | | | |
+| 2014-09-30 | The Dire Straits Experience | Music | Wellington | New Zealand | Michael Fowler Centre | | | |
+| 2014-09-19 | Boy and Bear, Mali Mali, Alexander Wildwood | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2014-08-28 | Kristin Hersh | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2014-08-08 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Mahler's 9th | | |
+| 2014-06-13 | NZ Symphony Orchestra | Orchestra | Wellington | New Zealand | Michael Fowler Centre | Beethoven's 4th & 5th | | |
+| 2014-06-06 | Chick Corea, Gary Burton | Music | Wellington | New Zealand | Michael Fowler Centre | Duets | | |
+| 2014-05-11 | Billy Connolly | Comedy | Wellington | New Zealand | TSB Arena | High Horse Tour | | |
+| 2014-05-03 | Arctic Monkeys, Pond | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2014-04-27 | Steve Earle and the Dukes, The Mastersons | Music | Wellington | New Zealand | St James Theatre | | | |
+| 2014-03-20 | Nine Inch Nails, Queens Of The Stone Age | Music | Wellington | New Zealand | TSB Arena | | | |
+| 2014-03-14 | Kimbra, Arrested Development, Tim Finn, Pokey Lafarge | Music | New Plymouth | New Zealand | Bowl of Brooklands | WOMAD New Zealand | | |
+| 2013-12-14 | Belinda Carlisle | Music | Wellington | New Zealand | The Opera House | | | |
+| 2013-12-02 | Iris DeMent | Music | Wellington | New Zealand | Old St Paul's | | | |
+| 2013-11-28 | Rules of Addiction | Music | Wellington | New Zealand | Bar Medusa | | | |
+| 2013-10-05 | 8 Foot Sativa, Gunt, Bulletbelt, Gift of Ruin | Music | Wellington | New Zealand | Bar Medusa | | | |
+| 2013-09-20 | Fat Freddy's Drop | Music | Wellington | New Zealand | The Opera House | Blackbird Album Release Tour | | |
+| 2013-09-12 | The Datsuns, Milk Train | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2013-07-27 | Shapeshifter | Music | Wellington | New Zealand | Wellington Town Hall | Delta Live | | |
+| 2013-05-05 | Tom Green | Comedy | Wellington | New Zealand | The Opera House | | | |
+| 2013-05-04 | Unida, Beastwars | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 2013-03-19 | Neil Young and Crazy Horse, Husky, The Drones | Music | Wellington | New Zealand | TSB Arena | | Neil Young | |
+| 2012-08-12 | Blur, New Order, The Specials | Music | London | United Kingdom | Hyde Park | BT London Live | | |
+| 2012-08-01 | Ella Fitzgerald Experience | Music | London | United Kingdom | Ronnie Scott's Jazz Club | | | |
+| 2012-07-28 | Eddie Vedder, Glen Hansard | Music | Manchester | United Kingdom | O2 Apollo | | | |
+| 2012-07-27 | Hollie Smith | Music | London | United Kingdom | Vandella | | | |
+| 2012-07-20 | Rhys Darby | Comedy | London | United Kingdom | Shepherd's Bush Empire | This Way to Spaceship | | |
+| 2012-07-17 | Madonna, LMFAO, Martin Solveig | Music | London | United Kingdom | Hyde Park | MDNA Tour | | |
+| 2012-07-14 | Bruce Springsteen, John Fogerty, Lady Antebellum, Amy Macdonald, Hey Monea! | Music | London | United Kingdom | Hyde Park | Hard Rock Calling. Guest appearances by Paul McCartney, John Fogerty, Tom Morello | | |
+| 2012-07-13 | Soundgarden, Iggy & the Stooges, Cold Chisel, Black Stone Cherry | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | | |
+| 2012-07-08 | Faith No More, Guano Padano | Music | London | United Kingdom | Hammersmith Apollo | Guest appearance by Danny DeVito | | |
+| 2012-07-06 | Deadmau5, The Roots, Santigold, Childish Gambino, Metric | Music | London | United Kingdom | Hyde Park | Wireless Festival | | |
+| 2012-06-26 | Robert Cray | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2012-06-20 | Tom Petty, Jonathan Wilson | Music | London | United Kingdom | Royal Albert Hall | | | |
+| 2012-06-05 | Cypress Hill | Music | London | United Kingdom | The Forum | | | |
+| 2012-06-02 | The Sunshine Boys | Theatre | London | United Kingdom | Savoy Theatre | Starring Danny DeVito, Richard Griffiths. Directed by Thea Sharrock | | |
+| 2012-05-26 | Judas Priest, Saxon | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2012-05-03 | Jose Gonzalez, Tinariwen | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2012-04-30 | Russian Circles, Wovenhand | Music | London | United Kingdom | Scala | | | |
+| 2012-03-25 | Korn, Downlink | Music | London | United Kingdom | Brixton Academy | | | |
+| 2012-03-20 | The Phantom Of The Opera | Theatre | London | United Kingdom | Her Majesty's Theatre | Starring Peter Jöback, Sofia Escobar. Directed by Harold Prince | | |
+| 2012-03-15 | Anthrax | Music | London | United Kingdom | Islington Academy | | | |
+| 2012-02-26 | Imogen Heap, Ana Silvera | Music | London | United Kingdom | Roundhouse | | | |
+| 2012-02-06 | Gilby Clarke, Badmouth | Music | London | United Kingdom | Underworld Camden | | | |
+| 2012-01-29 | Throwing Needles | Music | London | United Kingdom | | | | |
+| 2011-12-18 | The Royal Ballet | Other | London | United Kingdom | Royal Opera House | The Nutcracker | | |
+| 2011-12-14 | Def Leppard, Motley Crue, Steel Panther | Music | London | United Kingdom | Wembley Arena | | | |
+| 2011-11-26 | Dave Dobbyn | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2011-11-22 | Wye Oak | Music | London | United Kingdom | XOYO | | | |
+| 2011-11-19 | Bob Dylan, Mark Knopfler | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2011-11-15 | Roxette, Darren Hayes | Music | London | United Kingdom | Wembley Arena | | | |
+| 2011-11-02 | Throwing Muses, Spectrals | Music | London | United Kingdom | Shepherd's Bush Empire | | Kristin Hersh | |
+| 2011-10-29 | Alice Cooper, New York Dolls, Arthur Brown | Music | London | United Kingdom | Alexandra Palace | Guest appearance by Lou Reed | | |
+| 2011-10-27 | Lenny Kravitz | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2011-10-18 | Marketa Irglova | Music | London | United Kingdom | Bush Hall | | | |
+| 2011-10-12 | Brett Anderson | Music | London | United Kingdom | KOKO | | | |
+| 2011-10-01 | Von Hertzen Brothers | Music | London | United Kingdom | Borderline | | | |
+| 2011-09-02 | Doug Stanhope | Comedy | London | United Kingdom | Leicester Square Theatre | | | |
+| 2011-08-30 | Janes Addiction | Music | London | United Kingdom | KOKO | | | |
+| 2011-08-24 | Deftones, Pulled Apart By Horses | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2011-08-13 | Throwing Needles | Music | London | United Kingdom | Punk (Soho) | | | |
+| 2011-08-05 | Iron Maiden, DragonForce | Music | London | United Kingdom | The O2 Arena | | | |
+| 2011-07-29 | Placido Domingo, Angela Gheorghiu | Opera | London | United Kingdom | The O2 Arena | | | |
+| 2011-07-14 | Dylan Moran | Comedy | London | United Kingdom | Hammersmith Apollo | Yeah, Yeah | | |
+| 2011-07-06 | Weezer | Music | London | United Kingdom | Brixton Academy | | | |
+| 2011-06-30 | Cyndi Lauper, Charlie Musselwhite, Allen Toussaint | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2011-06-28 | BB King | Music | London | United Kingdom | Royal Albert Hall | Guest appearances by Slash, Ronnie Wood, Mick Hucknall, Derek Trucks, Susan Tedeschi | | |
+| 2011-06-25 | Bon Jovi, Stevie Nicks, Ray Davies, Black Cards, Lissie, Vintage Trouble | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | | |
+| 2011-06-21 | Ozzy Osbourne | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2011-06-18 | Simple Minds, James Walsh (Starsailor) | Music | Nottingham | United Kingdom | Sherwood Pines Park | Forest Live | | |
+| 2011-06-11 | Yelawolf | Music | Amsterdam | The Netherlands | Melkweg Oude Zaal | | | |
+| 2011-05-22 | The Straits | Music | London | United Kingdom | Royal Albert Hall | The Straits' debut public performance (charity show) | | |
+| 2011-05-20 | The Naked And Famous | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2011-05-18 | Roger Waters | Music | London | United Kingdom | The O2 | | | |
+| 2011-05-16 | Uncaged Monkeys | Other | London | United Kingdom | Hammersmith Apollo | Featuring Brian Cox, Ben Goldacre, Simon Singh, Robin Ince, Helen Arney | | |
+| 2011-05-05 | Paloma Faith | Music | London | United Kingdom | Union Chapel | | | |
+| 2011-04-11 | Jose Gonzalez, Gothenburg String Theory, Little Scream | Music | London | United Kingdom | Barbican Hall | | | |
+| 2011-04-08 | Ed Byrne | Comedy | London | United Kingdom | Hammersmith Apollo | Crowd Pleaser | | |
+| 2011-04-07 | Kylie Minogue, Ultra Girls | Music | London | United Kingdom | The O2 | | | |
+| 2011-03-23 | Cage The Elephant | Music | London | United Kingdom | Electric Ballroom | | | |
+| 2011-02-28 | Adler's Appetite | Music | London | United Kingdom | Underworld Camden | Guest appearance by Duff McKagan | | |
+| 2011-02-25 | Foo Fighters, Cee Lo Green, Band Of Horses, No Age | Music | London | United Kingdom | Wembley Arena | NME Awards Big Gig 2011 | | |
+| 2011-02-12 | Esben and the Witch | Music | Amsterdam | The Netherlands | Paradiso | | | |
+| 2010-11-21 | Soulfly | Music | London | United Kingdom | KOKO | | | |
+| 2010-11-19 | Therapy? | Music | London | United Kingdom | HMV Forum | | | |
+| 2010-11-17 | Deftones, Coheed and Cambria | Music | London | United Kingdom | Brixton Academy | | | |
+| 2010-11-11 | Linkin Park, Does It Offend You Yeah? | Music | London | United Kingdom | The O2 | | | |
+| 2010-10-23 | Morcheeba | Music | London | United Kingdom | Roundhouse | | | |
+| 2010-10-20 | Stephen Hawking | Other | London | United Kingdom | Royal Albert Hall | | | |
+| 2010-10-13 | Guns N' Roses, Sebastian Bach | Music | London | United Kingdom | The O2 | | | |
+| 2010-09-25 | Zodiac Mindwarp | Music | London | United Kingdom | Borderline | | | |
+| 2010-07-24 | The Prodigy, Pendulum, Chase & Status, Enter Shikari | Music | Milton Keynes | United Kingdom | Milton Keynes Bowl | Warriors Dance Festival | | |
+| 2010-07-22 | Sepultura, Gama Bomb | Music | London | United Kingdom | Scala | | | |
+| 2010-07-17 | Penn & Teller | Comedy | London | United Kingdom | Hammersmith Apollo | | | |
+| 2010-07-14 | Gil Scott-Heron | Music | London | United Kingdom | Somerset House | | | |
+| 2010-06-29 | Melissa Etheridge | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2010-06-27 | Paul McCartney, Crowded House, Crosby Stills & Nash, Elvis Costello | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | Neil Finn | |
+| 2010-06-04 | Pixies | Music | London | United Kingdom | Troxy | | Frank Black | |
+| 2010-06-03 | Love Never Dies | Theatre | London | United Kingdom | Adelphi Theatre | Starring Ramin Karimloo, Sierra Boggess, Summer Strallen. Directed by Jack O'Brien | | |
+| 2010-05-31 | Sunny Day Real Estate, Biffy Clyro | Music | London | United Kingdom | HMV Forum | | | |
+| 2010-05-24 | Hope Sandoval, Dirt Blue Gene | Music | London | United Kingdom | Bush Hall | | | |
+| 2010-05-04 | Belinda Carlisle | Music | London | United Kingdom | Jazz Cafe | | | |
+| 2010-04-28 | Ricky Gervais | Comedy | London | United Kingdom | Wembley Arena | Science | | |
+| 2010-04-23 | Rhod Gilbert | Comedy | London | United Kingdom | Hammersmith Apollo | The Cat That Looked like Nicholas Lyndhurst | | |
+| 2010-04-13 | Joe Perry Project | Music | London | United Kingdom | 100 Club | | | |
+| 2010-04-01 | Airbourne, Black Spiders, Taking Dawn | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2010-02-20 | Depeche Mode, Nitzer Ebb | Music | London | United Kingdom | The O2 Arena | | | |
+| 2009-12-19 | Nine Lessons and Carols for Godless People | Other | London | United Kingdom | UCL Bloomsbury | Featuring Brian Cox, Richard Dawkins, Ben Goldacre, Simon Singh, Johnny Ball, Mark Steel, Shappi Khorsandi, Josie Long, Richard Herring, Chris Addison, Al Murray, Robyn Hitchcock, the Mystery Fax Machine Chamber Orchestra, Gavin Osborn | | |
+| 2009-12-10 | Marilyn Manson, Esoterica | Music | London | United Kingdom | Brixton Academy | | | |
+| 2009-12-09 | Placebo, Silversun Pickups, The Horrors | Music | London | United Kingdom | The O2 Arena | | | |
+| 2009-12-02 | W.A.S.P., The Glitterati | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2009-11-19 | Julian Clary | Comedy | London | United Kingdom | Leicester Square Theatre | | | |
+| 2009-11-17 | Alice In Chains, Little Fish | Music | London | United Kingdom | HMV Forum | | | |
+| 2009-11-12 | Biffy Clyro, Manchester Orchestra | Music | London | United Kingdom | Brixton Academy | | | |
+| 2009-11-05 | Othello | Theatre | London | United Kingdom | Trafalgar Studios | Starring Lenny Henry, Conrad Nelson. Directed by Barrie Rutter | | |
+| 2009-11-01 | Europe | Music | London | United Kingdom | Relentless Garage | | | |
+| 2009-10-28 | ZZ Top, Steel Panther | Music | London | United Kingdom | Wembley Arena | | | |
+| 2009-10-10 | The Cult, Aqua Nebula Oscillator | Music | London | United Kingdom | Royal Albert Hall | | | |
+| 2009-10-07 | Pixies | Music | London | United Kingdom | Brixton Academy | | Frank Black | |
+| 2009-09-24 | JTQ + The Ronnie Scott's All Stars | Music | London | United Kingdom | Ronnie Scott's Jazz Club | | James Taylor Quartet | |
+| 2009-09-19 | Coldplay, Jay-Z, White Lies, Girls Aloud | Music | London | United Kingdom | Wembley Stadium | | | |
+| 2009-09-17 | Massive Attack | Music | London | United Kingdom | Brixton Academy | | | |
+| 2009-09-16 | Dame Kiri Te Kanawa | Opera | London | United Kingdom | The Tower of London | Continental Airlines Tower Festival | | |
+| 2009-09-04 | Doug Stanhope | Comedy | London | United Kingdom | Leicester Square Theatre | | | |
+| 2009-08-29 | Sasha & Digweed, David Guetta, Eric Prydz, Armin Van Buuren, Above & Beyond, Richie Hawtin | Music | London | United Kingdom | Clapham Common | South West Four (SW4) 2009 | | |
+| 2009-08-27 | Deftones, Rival Schools | Music | London | United Kingdom | HMV Forum | | | |
+| 2009-08-18 | Pearl Jam | Music | London | United Kingdom | The O2 Arena | | Eddie Vedder | |
+| 2009-08-04 | Alice In Chains | Music | London | United Kingdom | Scala | | | |
+| 2009-07-04 | Jeff Beck, Imelda May, Tal Wilkenfeld | Music | London | United Kingdom | Royal Albert Hall | Guest appearance by David Gilmour | | |
+| 2009-06-28 | Bruce Springsteen, Dave Matthews Band, James Morrison, The Gaslight Anthem | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | | |
+| 2009-06-27 | Neil Young, The Pretenders, Seasick Steve, Fleet Foxes, Ben Harper & Relentless7 | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | Ben Harper | |
+| 2009-06-26 | AC/DC, The Answer, The Subways | Music | London | United Kingdom | Wembley Stadium | | | |
+| 2009-06-25 | Chicken Foot, Skin | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2009-06-18 | Tesla | Music | London | United Kingdom | Islington Academy | | | |
+| 2009-06-16 | Anthrax, Trigger the Bloodshed, Suicide Silence | Music | London | United Kingdom | ULU | | | |
+| 2009-06-10 | Faith No More, Selfish Cunt | Music | London | United Kingdom | Brixton Academy | | | |
+| 2009-06-06 | James Taylor Quartet | Music | London | United Kingdom | 100 Club | | | |
+| 2009-06-03 | Waiting for Godot | Theatre | London | United Kingdom | Theatre Royal Haymarket | Starring Ian McKellen, Patrick Stewart, Simon Callow. Directed by Sean Mathias | | |
+| 2009-05-05 | Therapy? | Music | London | United Kingdom | Islington Academy | | | |
+| 2009-05-03 | Gary Moore | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2009-03-30 | Sinead O'Connor | Music | London | United Kingdom | The Pigalle Club | | | |
+| 2009-03-28 | Metallica, Machine Head, The Sword | Music | London | United Kingdom | The O2 Arena | | | |
+| 2009-03-13 | Oliver | Theatre | London | United Kingdom | Theatre Royal Drury Lane | Starring Rowan Atkinson, Jodie Prenger. Directed by Rupert Goold | | |
+| 2009-02-21 | Judas Priest, Megadeth, Testament | Music | London | United Kingdom | Wembley Arena | | | |
+| 2009-02-18 | The Datsuns | Music | London | United Kingdom | Underworld Camden | | | |
+| 2008-12-21 | Nine Lessons and Carols for Godless People | Other | London | United Kingdom | Hammersmith Apollo | Featuring Richard Dawkins, Ben Goldacre, Simon Singh, Stewart Lee, Ricky Gervais, Josie Long, Tim Minchin, Richard Herring, Natalie Haynes, Chris Addison, Mark Thomas, Phil Jupitus, Dara Ó Briain, Jo Neary, Peter Buckley Hill, Jarvis Cocker, Robyn Hitchcock, Darren Hayman, Waen Shepherd, The Martin White Mini Fax Machine Orchestra, Gavin Osborn | Ricky Gervais | |
+| 2008-12-17 | Biffy Clyro, Frightened Rabbit, People in Planes | Music | London | United Kingdom | Brixton Academy | | | |
+| 2008-12-09 | Bill Bailey | Comedy | London | United Kingdom | Gielgud Theatre | Tinselworm | | |
+| 2008-12-07 | Coldplay | Music | Glasgow | United Kingdom | SECC | | | |
+| 2008-12-03 | Slipknot, Machine Head, Children of Bodom | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2008-11-24 | Dylan Moran | Comedy | London | United Kingdom | Hammersmith Apollo | What It Is | | |
+| 2008-11-23 | Kristin Hersh | Music | London | United Kingdom | Borderline | | | |
+| 2008-11-05 | Bryan Adams | Music | London | United Kingdom | The O2 | | | |
+| 2008-10-25 | Cypress Hill | Music | London | United Kingdom | Battersea Power Station | Freeze Festival | | |
+| 2008-10-24 | Aimee Mann, The Submarines | Music | London | United Kingdom | IndigO2 (The O2) | | | |
+| 2008-10-16 | Spiritualized | Music | London | United Kingdom | Roundhouse | | | |
+| 2008-10-01 | Seasick Steve, Amy LaVere | Music | London | United Kingdom | Royal Albert Hall | | | |
+| 2008-09-30 | Brett Anderson, Kid Harpoon | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2008-09-27 | Supergroove | Music | London | United Kingdom | Olympia Grand Hall | | | |
+| 2008-09-26 | LA Guns, Love/Hate | Music | London | United Kingdom | Islington Academy | | | |
+| 2008-09-23 | Nigel Kennedy Quintet | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2008-09-18 | Duff McKagen | Music | London | United Kingdom | Islington Academy | | | |
+| 2008-09-17 | Doug Stanhope | Comedy | London | United Kingdom | Arts Theatre | | | |
+| 2008-09-16 | Riflemind | Theatre | London | United Kingdom | Trafalgar Studios | Starring John Hannah, Paul Hilton. Directed by Philip Seymour Hoffman | | |
+| 2008-09-13 | Allanah Myles | Music | London | United Kingdom | Underworld Camden | | | |
+| 2008-09-09 | The Datsuns | Music | London | United Kingdom | Barfly | | | |
+| 2008-08-31 | Heaven and Hell, Motorhead, Judas Priest, Testament | Music | Mountain View | United States of America | Shoreline Ampitheatre | Metal Masters Tour | | |
+| 2008-08-24 | Metallica, Tenacious D, Slipknot, Feeder, Avenged Sevenfold, Dropkick Murphys | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | | |
+| 2008-08-23 | Carl Cox, Erick Morillo, John Digweed, Fedde Le Grand, Layo & Bushwacka!, Paolo Mojo | Music | London | United Kingdom | Clapham Common | South West Four (2008). Guest appearance by Danny Tenaglia | | |
+| 2008-08-20 | Maceo Parker | Music | London | United Kingdom | The Pigalle Club | | | |
+| 2008-08-13 | Lenny Kravitz, Sons of Albion | Music | London | United Kingdom | Brixton Academy | | | |
+| 2008-07-31 | Billy Idol | Music | London | United Kingdom | Brixton Academy | | | |
+| 2008-07-20 | Nigel Kennedy, BBC Concert Orchestra | Orchestra | London | United Kingdom | Royal Albert Hall | BBC Proms 2008 | | |
+| 2008-07-19 | Jill Scott | Music | London | United Kingdom | Brixton Academy | | | |
+| 2008-07-16 | Fat Pig | Theatre | London | United Kingdom | Trafalgar Studios | Starring Kris Marshall, Robert Webb. Directed by Neil LaBute | | |
+| 2008-07-13 | The Year of Magical Thinking | Theatre | London | United Kingdom | National Theatre | Starring Vanessa Redgrave. Directed by David Hare | | |
+| 2008-07-10 | The Frontline | Theatre | London | United Kingdom | Shakespeare's Globe | Starring Naana Agyei-Ampadu, Trystan Gravells. Directed by Matthew Dunster | | |
+| 2008-07-05 | Iron Maiden, Avenged Sevenfold, Within Temptation, Lauren Harris | Music | London | United Kingdom | Twickenham Stadium | | | |
+| 2008-07-03 | Duran Duran, The Duke Spirit, The Real People | Music | London | United Kingdom | The O2 | | | |
+| 2008-06-28 | Eric Clapton, Sheryl Crow, John Mayer, Jason Mraz, Robert Randolph and The Family Band, Steve Boyce Band | Music | London | United Kingdom | Hyde Park | Hard Rock Calling | | |
+| 2008-06-27 | Bon Jovi, The Feeling, Ivy Rise | Music | London | United Kingdom | Twickenham Stadium | | | |
+| 2008-06-26 | Def Leppard, Whitesnake, Black Stone Cherry | Music | London | United Kingdom | Wembley Arena | | | |
+| 2008-06-25 | Radiohead | Music | London | United Kingdom | Victoria Park | | | |
+| 2008-06-15 | Radiohead, Bat For Lashes | Music | Nimes | France | Arènes de Nîmes | | | |
+| 2008-06-10 | The Herbaliser | Music | London | United Kingdom | 93 Feet East | | | |
+| 2008-05-29 | We Will Rock You | Theatre | London | United Kingdom | Dominion Theatre | Directed by Christopher Renshaw | | |
+| 2008-05-26 | Mark Knopfler, Bap Kennedy | Music | London | United Kingdom | Royal Albert Hall | | | |
+| 2008-05-23 | Public Enemy, Dr Octagon (Kool Keith), Kutmasta Kurt, Edan, Anti Pop Consortium, MC Dagha | Music | London | United Kingdom | Brixton Academy | | | |
+| 2008-05-17 | The Trailer Boat Ride | Music | London | United Kingdom | | | | |
+| 2008-04-16 | The Breeders | Music | London | United Kingdom | KOKO | | | |
+| 2008-04-14 | Hollie Smith | Music | London | United Kingdom | 12 Acklam Rd | | | |
+| 2008-04-11 | Jose Gonzalez | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2008-04-10 | Portishead | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2008-04-09 | Black Crowes | Music | London | United Kingdom | Brixton Academy | | | |
+| 2008-04-08 | English National Opera | Opera | London | United Kingdom | London Coliseum | David Lynch's Lost Highway | | |
+| 2008-03-20 | The Cure, 65 Days of Static | Music | London | United Kingdom | Wembley Arena | | | |
+| 2008-03-16 | Neil Young | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2008-03-07 | Apocolyptica | Music | London | United Kingdom | The Forum, Kentish Town | | | |
+| 2008-02-29 | Speed-the-plow | Theatre | London | United Kingdom | The Old Vic | Starring Kevin Spacey, Jeff Goldblum, Laura Michelle Kelly. Directed by Matthew Warchus | | |
+| 2008-02-24 | Tiesto, Ferry Corsten, Marco V, Sander van Doorn | Music | Utrecht | The Netherlands | Jaarbeurs (Trance Energy) | Trance Energy | | |
+| 2008-02-16 | Ninja Tune, The Bug (Flowdan), Plastician, Ghislain Poirier, Bonobo, DJ Food, Coldcut (Jon More), zero dB, The Death Set, X Rabit | Music | London | United Kingdom | Electrowerkz | Ninja Tune presents You Don't Know | | |
+| 2008-02-02 | Great White | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2007-12-13 | Chemical Bros, Simian Mobile Disco | Music | London | United Kingdom | Brixton Academy | | | |
+| 2007-11-29 | Macbeth | Theatre | London | United Kingdom | Gielgud Theatre | Starring Patrick Stewart, Kate Fleetwood. Directed by Rupert Goold | | |
+| 2007-11-28 | English National Opera | Opera | London | United Kingdom | London Coliseum | Aida | | |
+| 2007-11-24 | Amy Winehouse | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2007-11-23 | The Hives | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2007-11-17 | Alice Cooper, Motorhead, Joan Jett | Music | London | United Kingdom | Wembley Arena | | | |
+| 2007-11-16 | Gary Moore | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2007-11-14 | Sex Pistols | Music | London | United Kingdom | Brixton Academy | | | |
+| 2007-11-10 | Heaven and Hell, Lamb of God, Iced Earth | Music | London | United Kingdom | Wembley Arena | | | |
+| 2007-11-08 | Lez Zeppelin | Music | London | United Kingdom | Mean Fiddler | | | |
+| 2007-11-05 | Tesla, Killing For Company | Music | London | United Kingdom | Islington Academy | | | |
+| 2007-11-02 | W.A.S.P. | Music | London | United Kingdom | London Astoria | | | |
+| 2007-10-23 | LCD Soundsystem | Music | London | United Kingdom | Brixton Academy | | | |
+| 2007-10-18 | Underworld | Music | London | United Kingdom | Roundhouse | | | |
+| 2007-10-11 | Turin Brakes | Music | London | United Kingdom | The Forum | | | |
+| 2007-10-09 | Swimming with Sharks | Theatre | London | United Kingdom | Vaudeville Theatre | Starring Christian Slater, Matt Smith, Helen Baxendale. Directed by Wilson Milam | | |
+| 2007-10-06 | Amp Fiddler | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2007-09-29 | Russell Brand | Comedy | London | United Kingdom | Hackney Empire | Only Joking | | |
+| 2007-09-18 | Kosheen | Music | London | United Kingdom | KOKO | | | |
+| 2007-09-07 | The Jesus and Mary Chain, The Horrors, Evan Dando | Music | London | United Kingdom | Brixton Academy | | | |
+| 2007-09-06 | Beastie Boys | Music | London | United Kingdom | Roundhouse | | | |
+| 2007-08-26 | The Smashing Pumpkins, Nine Inch Nails, Lostprophets, Fall Out Boy, Funeral for a Friend, The Used, Billy Talent | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | | |
+| 2007-08-25 | Red Hot Chili Peppers, Arcade Fire, Bloc Party, Panic! At The Disco, Angels and Airwaves, Eagles of Death Metal, Paramore, Unkle, Biffy Clyro, The Shins, Dinosaur Jr | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | | |
+| 2007-08-24 | Razorlight, Kings of Leon, Interpol, Maximo Park, Jimmy Eat World, Gossip, Gogol Bordello, Ash, Brand New | Music | Reading | United Kingdom | Richfield Avenue (Reading Festival) | Reading Festival | | |
+| 2007-08-21 | Tool | Music | London | United Kingdom | Brixton Academy | | | |
+| 2007-08-17 | Prince | Music | London | United Kingdom | The O2 Arena | 21 Nights in London: The Earth Tour | | |
+| 2007-08-10 | BBC Concert Orchestra | Orchestra | London | United Kingdom | Royal Albert Hall | BBC Proms 36 | | |
+| 2007-07-30 | Scorpions, Michael Schenker Group (MSG) | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2007-07-15 | Frank Black | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2007-07-14 | Bert Jansch, Beth Orton, Bernard Butler | Music | London | United Kingdom | Somerset House | | | |
+| 2007-07-08 | Metallica, Machine Head, Mastodon, H.I.M. | Music | London | United Kingdom | Wembley Stadium | | | |
+| 2007-07-07 | Madonna, Red Hot Chili Peppers, Genesis, Duran Duran, Metallica, Foo Fighters, Beastie Boys, Snow Patrol, Keane, Black Eyed Peas, John Legend, David Gray, Damien Rice, Corinne Bailey Rae, James Blunt, Kasabian, Bloc Party, Paolo Nutini, Pussycat Dolls | Music | London | United Kingdom | Wembley Stadium | Live Earth | | |
+| 2007-07-06 | Seal | Music | London | United Kingdom | Tower of London | | | |
+| 2007-07-04 | Tori Amos | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2007-06-28 | Tesla | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2007-06-27 | Fat Freddy's Drop | Music | London | United Kingdom | Astoria | | | |
+| 2007-06-24 | Aerosmith, Chris Cornell, Jet, The Answer | Music | London | United Kingdom | Hyde Park | Hyde Park Calling | | |
+| 2007-06-23 | Peter Gabriel, Crowded House, The Feeling, Ghosts | Music | London | United Kingdom | Hyde Park | Hyde Park Calling | Neil Finn | |
+| 2007-06-22 | The Jesus and Mary Chain | Music | London | United Kingdom | Royal Festival Hall | Meltdown 2007 | | |
+| 2007-06-17 | Muse, Biffy Clyro, My Chemical Romance | Music | London | United Kingdom | Wembley Stadium | | | |
+| 2007-06-11 | Motley Crue | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2007-05-01 | Money Mark | Music | London | United Kingdom | ICA | | | |
+| 2007-04-26 | Spiritualized | Music | London | United Kingdom | Shepherd's Bush Empire | Acoustic Mainlines | | |
+| 2007-03-12 | Avenue Q | Theatre | London | United Kingdom | Noel Coward Theatre | Starring Luke Evans, Jon Robyns, Julie Atherton. Directed by Jason Moore | | |
+| 2007-02-15 | Indigo Girls | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2007-02-08 | Massive Attack | Music | London | United Kingdom | Brixton Academy | | | |
+| 2007-02-06 | Wolfmother | Music | London | United Kingdom | Hammersmith Apollo | | | |
+| 2006-12-23 | Iron Maiden, Trivium, Lauren Harris | Music | London | United Kingdom | Earls Court | | | |
+| 2006-12-03 | The Zutons | Music | London | United Kingdom | Roundhouse | | | |
+| 2006-11-27 | Tool, Mastodon | Music | London | United Kingdom | Wembley Arena | | | |
+| 2006-11-17 | W.A.S.P., Jaded | Music | London | United Kingdom | London Astoria | | | |
+| 2006-11-12 | Bruce Springsteen | Music | London | United Kingdom | Wembley Arena | Guest appearance by Nils Lofgren | | |
+| 2006-11-08 | The Datsuns | Music | London | United Kingdom | Electric Ballroom | | | |
+| 2006-11-07 | INXS | Music | London | United Kingdom | Shepherd's Bush Empire | | | |
+| 2006-10-21 | Salmonella Dub | Music | London | United Kingdom | Shepherd's Bush Empire | | Tiki Taane | |
+| 2006-10-08 | Sander Kleinenberg, Mark Knight, Sebastien Leger, Martijn Ten Velden, Nick Bridges | Music | London | United Kingdom | Ministry of Sound | | | |
+| 2006-09-16 | English National Opera | Opera | London | United Kingdom | Coliseum | Gaddafi: A Living Myth | | |
+| 2006-09-12 | Pearl Jam, My Morning Jacket | Music | Paris | France | Palais Omnisports de Paris-Bercy | | Eddie Vedder | |
+| 2006-08-26 | Sander Kleinenberg, Steve Lawler, Carl Cox, Paul Oakenfold, John Digweed, Pete Tong, Judge Jules, Seb Fontaine, Danny Howells, Fergie, The Shapeshifters, Mauro Picotto, Stanton Warriors, Nic Fanciulli, Sander van Doorn, Desyn Masiello, James Zabiela, Ian Betts, Matt Hardwick | Music | London | United Kingdom | Clapham Common | South West Four (SW4) 2006 | | |
+| 2006-06-17 | Foo Fighters, Motorhead, Queens Of The Stone Age, Angels and Airwaves, Juliette & The Licks, The Subways | Music | London | United Kingdom | Hyde Park | Guest appearances by Lemmy, Brian May, Roger Taylor | | |
+| 2004-12-27 | Tenacious D | Music | Wellington | New Zealand | St James Theatre | | | |
+| 2004-12-17 | Cypress Hill | Music | Wellington | New Zealand | Starlight Ballroom | | | |
+| 2003-04-24 | Morcheeba | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 2002-07-11 | The Breeders | Music | San Francisco | United States of America | The Fillmore | | | |
+| 2002-07-05 | The Cranberries | Music | Los Angeles | United States of America | Greek Theatre | | | |
+| 2002-04-19 | Tool | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
+| 2001-05-10 | Pantera | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
+| 2000-05-01 | ZZ Top | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
+| 1999-10-02 | Alanis Morissette | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
+| 1999-05-30 | Beastie Boys, DJ Mix Master Mike | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1999-04-17 | Keb' Mo', Paul Ubana Jones | Music | Wellington | New Zealand | State Opera House | | | |
+| 1999-03-15 | Jaunt, The Whores Next Door, Pushkin | Music | Wellington | New Zealand | Indigo | | | |
+| 1998-11-27 | Pushkin, The Whores Next Door, Broomdance | Music | Wellington | New Zealand | Indigo | | | |
+| 1998-11-13 | Bongmaster, Hell Is Other People, Shihad | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood | |
+| 1998-10-24 | Salvage, Whores Next Door, Wretched Skinny, Empty Quarter | Music | Wellington | New Zealand | Black Kat Cafe | | | |
+| 1998-10-09 | The Living End, Brubeck | Music | Wellington | New Zealand | James Cabaret | | | |
+| 1998-10-01 | Whores Next Door, Tau, Empty Quarter | Music | Wellington | New Zealand | Indigo | | | |
+| 1998-09-25 | Whores, Empty Quarter, Wretched Skinny, Trawler, Big Blue Blanket | Music | Wellington | New Zealand | Black Kat Cafe | | | |
+| 1998-09-18 | Fur Patrol, Weta | Music | Wellington | New Zealand | Indigo | | Aaron Tokona | |
+| 1998-09-14 | Death In June | Music | Wellington | New Zealand | Indigo | | | |
+| 1998-09-03 | The Whores Next Door, Lamps, Pushkats | Music | Wellington | New Zealand | Indigo | | | |
+| 1998-08-21 | The Whores Next Door, Empty Quarter | Music | Wellington | New Zealand | Black Kat Cafe | | | |
+| 1998-08-19 | The Whores Next Door, Trinity, Salvage | Music | Wellington | New Zealand | Victoria University of Wellington | Battle of the Bands | | |
+| 1998-07-25 | Alex Paterson, Coda | Music | Wellington | New Zealand | Escape | | | |
+| 1998-06-13 | Whores Next Door, Wretched Skinny | Music | Wellington | New Zealand | Black Kat Cafe | | | |
+| 1998-04-09 | Breathe, The Stereo Bus, Tim Finn, DLT & Che Fu, Head Like A Hole | Music | Wellington | New Zealand | Wellington Town Hall | | DLT, Che Fu | |
+| 1998-04-08 | Portishead | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1998-03-10 | Cassandra Wilson | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1998-02-19 | Foo Fighters, Weta | Music | Wellington | New Zealand | Wellington Town Hall | | Aaron Tokona | |
+| 1998-01-29 | Radiohead | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
+| 1997-10-03 | Bike, Breakfast of Champions | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1997-07-05 | Faith No More, Better Than Ezra, The Nixons, Orbit, Muse | Music | Fort Lauderdale | United States of America | Markham Park | Zetafest | | |
+| 1997-04-05 | Head Like A Hole | Music | Wellington | New Zealand | Civic Square | | | |
+| 1997-03-13 | Baconfoot, Snitches, Gas Huffer | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1997-03-07 | Head Like A Hole, Frenzal Rhomb | Music | Wellington | New Zealand | Union Hall | | | |
+| 1997-03-05 | Superette | Music | Wellington | New Zealand | Union Hall | | | |
+| 1997-03-04 | David Harrow, Salmonella Dub | Music | Wellington | New Zealand | Union Hall | | Tiki Taane | |
+| 1997-02-22 | ENZSO | Music | Upper Hutt | New Zealand | Trentham Memorial Park | Featuring Split Enz / NZ Symphony Orchestra | Neil Finn, Tim Finn, NZ Symphony Orchestra | |
+| 1997-02-21 | Letterbox Lambs, Superette | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1997-01-22 | The Exponents, Pash | Music | Wellington | New Zealand | James Cabaret | | Jordan Luck | |
+| 1997-01-16 | Soundgarden, Weta | Music | Wellington | New Zealand | Wellington Town Hall | | Aaron Tokona | |
+| 1997-01-05 | Weta, Breathe, Short | Music | Wellington | New Zealand | Civic Square | | Aaron Tokona | |
+| 1996-12-18 | The Warners | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1996-05-10 | Shihad | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood | |
+| 1996-05-04 | Red Hot Chilli Peppers, Thorazine Shuffle | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
+| 1996-04-10 | Atomic Blossom | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1996-01-19 | Skwish | Music | Wellington | New Zealand | | | | |
+| 1996-01-11 | Knightshade, Dave Dobbyn, Muttonbirds, Joe Satriani, Stranglers, The Cruel Sea, Mental As Anything, The Exponents, Barry Saunders, Head Like A Hole, Pumpkinhead | Music | Woodville | New Zealand | Airlie Brae | Mountain Rock 5 | Don McGlashan, Jordan Luck | |
+| 1995-10-01 | Skwish | Music | Wellington | New Zealand | Cuba Cuba | | | |
+| 1995-08-11 | Shihad, Short | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood | |
+| 1995-08-05 | Faith No More, Pumpkinhead, Dead Flowers | Music | Wellington | New Zealand | Wellington Show + Sports Centre | | | |
+| 1995-08-04 | Letterbox Lambs, Breathe | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1995-08-02 | Condition Red | Music | Wellington | New Zealand | Antipodes | | | |
+| 1995-07-31 | Dave Dobbyn, Emma Paki | Music | Wellington | New Zealand | James Cabaret | | | |
+| 1995-05-25 | Sweet Family Unit | Music | Wellington | New Zealand | Antipodes | | | |
+| 1995-04-01 | Squirm | Music | Wellington | New Zealand | Antipodes | | | |
+| 1995-01-19 | The Cult, Fat Mannequin | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1995-01-14 | No Thrills, Head Like A Hole, Greg Johnson, Yothu Yindi, The Exponents, Tama Renata, Upper Hutt Posse, Brainchilds, Muttonbirds, Supergroove, Midnight Oil, Dave Dobbyn, Tim Finn, Semi Lemon Kola | Music | Woodville | New Zealand | | Mountain Rock IV | Che Fu, DLT, Don McGlashan, Jordan Luck | |
+| 1994-12-22 | Stonor, Nefretete, Wormhole, Rollie Stones | Music | Lower Hutt | New Zealand | Lucky Jacks | | | |
+| 1994-12-17 | Stonor | Music | Grenada North | New Zealand | Warehouse | | | |
+| 1994-12-09 | Slink Patrol, Skwish, Stonor | Music | Wellington | New Zealand | Thistle Hall | | | |
+| 1994-11-30 | Tori Amos, Ted Brown | Music | Auckland | New Zealand | Auckland Town Hall | | | |
+| 1994-11-26 | Stonor | Music | Lower Hutt | New Zealand | Miller Bar | | | |
+| 1994-11-18 | Stonor | Music | Wellington | New Zealand | 38 Norway St | | | |
+| 1994-11-06 | Pantera, Fat Mannequin | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1994-11-02 | Skwish, Plankton | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1994-10-05 | Beastie Boys, Helmet, Emulsifier | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1994-08-27 | Supergroove, Nixons, MCOJ & DLT | Music | Wellington | New Zealand | James Cabaret | | Che Fu | |
+| 1994-08-04 | Skwish | Music | Wellington | New Zealand | Bar Bodega | | | |
+| 1994-07-23 | Supergroove, Thorazine Shuffle, DLT | Music | Wellington | New Zealand | James Cabaret | | Che Fu | |
+| 1994-07-01 | Head Like A Hole, Monster | Music | Wellington | New Zealand | Union Hall | | | |
+| 1994-06-23 | Kristin Hersh, Brainchilds | Music | Wellington | New Zealand | Paramount Theatre | | | |
+| 1994-05-27 | Burning Roses, The Crystalline | Music | Wellington | New Zealand | Union Building, Victoria University | | | |
+| 1994-05-21 | Desert Road | Music | Wellington | New Zealand | Metro | | | |
+| 1994-04-27 | Muttonbirds, Emma Paki, Bilge Festival | Music | Wellington | New Zealand | James Cabaret | | Don McGlashan | |
+| 1994-03-01 | The 3Ds, Bailter Space, Solid Gold Hell | Music | Wellington | New Zealand | Union Hall | | | |
+| 1994-02-27 | JPSE, Cinematic | Music | Wellington | New Zealand | Union Hall | | | |
+| 1994-02-25 | Crowded House, Dave Dobbyn, Annie Crummer | Music | Wellington | New Zealand | Wellington Town Hall | Freedom | Neil Finn | |
+| 1994-02-05 | Soundgarden, The Smashing Pumpkins, Shihad, Head Like A Hole, Muttonbirds, JPSE, The Breeders, Urge Overkill, Hard-Ons, Jan Hellriegel, Cruel Sea, Kid Eternity | Music | Auckland | New Zealand | Mount Smart Stadium | Big Day Out | Jon Toogood, Don McGlashan | |
+| 1994-02-04 | Boney M | Music | Hamilton | New Zealand | Hamilton Domain | | | |
+| 1994-01-15 | Supergroove, Andrew Fagan, The Warratahs, R. Bryant, K Borich, Hello Sailor, Jan Hellriegel, Dave Dobbyn, Shona Laing, Straitjacket Fits, Desert Road, The Exponents, Drawn, Wildfire, Shihad, Head Like A Hole, Dead Flowers | Music | Woodville | New Zealand | | Mountain Rock III | Barry Saunders, Che Fu, Jon Toogood, Jordan Luck | |
+| 1994-01-14 | Dave Dobbyn, The Exponents | Music | Wellington | New Zealand | James Cabaret | | Jordan Luck | |
+| 1993-12-17 | Premature Autopsy, Loves Ugly Children, Head Like A Hole, Shihad | Music | Wellington | New Zealand | Union Hall | | Jon Toogood | |
+| 1993-11-18 | Karnage, Warpspasm, Carcass | Music | Wellington | New Zealand | Stox | | | |
+| 1993-09-16 | Glass Candle Grenade, Wake | Music | Wellington | New Zealand | Kaminskys | | | |
+| 1993-09-12 | Living Colour, Big Deal | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1993-08-15 | Wellington Youth Choir, Manawatu Youth Choir | Music | Wellington | New Zealand | | | | |
+| 1993-07-28 | Pungent Stench, Tension, Warp Drive | Music | Wellington | New Zealand | Kaminskys | | | |
+| 1993-07-23 | Shihad, Skinshed, Flail | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood | |
+| 1993-07-02 | Head Like A Hole, Steak, Funkmutha | Music | Wellington | New Zealand | Stox | | | |
+| 1993-05-22 | Push Push, The Spirals | Music | Wellington | New Zealand | Show & Sports Centre | | | |
+| 1993-05-13 | Faith No More, Emulsifier | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1993-04-23 | JPSE | Music | Wellington | New Zealand | Sol Bar | | | |
+| 1993-04-17 | Dead Flowers, Andrew Fagan, Big Deal, Ugly Truth, Open Oyster, Wildfire | Music | Wellington | New Zealand | Shed 11 | | | |
+| 1993-04-03 | Shihad, Conventional Toasters, Funkmutha | Music | Wellington | New Zealand | James Cabaret | | Jon Toogood | |
+| 1993-03-04 | JPSE, Muttonbirds | Music | Wellington | New Zealand | Union Hall | | Don McGlashan | |
+| 1993-03-02 | The Lemonheads, David Kilgour, Bilge Festival | Music | Wellington | New Zealand | Union Hall | | Evan Dando | |
+| 1993-02-25 | Billy Connolly | Comedy | Wellington | New Zealand | Michael Fowler Centre | | | |
+| 1993-02-06 | Guns N' Roses, Skid Row, Dead Flowers | Music | Auckland | New Zealand | Mount Smart Stadium | | Duff McKagen, Gilby Clarke, Sebastian Bach, Slash | |
+| 1993-01-16 | Shona Laing, Sam Hunt, Push Push, Shihad, Muttonbirds, Ted Clarke, Jan Hellriegel, Desert Road, Nine Livez, Dead Flowers, Southside of Bombay, Big Deal, Blue Buffoons, Flippin Hippies, Savana, Johnny B Band, Out of the Blue, Snowline | Music | Woodville | New Zealand | Airlie Brae | Mountain Rock II | Don McGlashan, Jon Toogood | |
+| 1993-01-11 | Jenny Morris, JPSE | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1993-01-02 | Archies Aunts, Charlotte Sometimes, Shona Laing,  Merenia | Music | Wellington | New Zealand | Civic Square | | | |
+| 1992-12-10 | Malchicks, The Exponents | Music | Wellington | New Zealand | James Cabaret | | Jordan Luck | |
+| 1992-11-08 | Still, Kamikaze Daydream | Music | Wellington | New Zealand | Dragons | | | |
+| 1992-08-13 | The Cure, Jan Hellriegel | Music | Wellington | New Zealand | Wellington Town Hall | | | |
+| 1992-05-17 | Scarf | Music | Hastings | New Zealand | Club Ew-els | | | |
+| 1992-04-16 | Braintree, Shihad | Music | Wellington | New Zealand | New Carpark | | Jon Toogood | |
+| 1992-04-03 | Buddakhan, The Exponents | Music | Wellington | New Zealand | New Carpark | | Jordan Luck | |
+| 1992-03-07 | Scios, Slaine, Sacrament, Deliverance, Vas Deferens | Music | Wellington | New Zealand | New Carpark | | | |
+| 1992-01-25 | Midge Marsden, Push Push, Dick Thrust, Shihad, Desert Road, Southside of Bombay, Lets Planet, Big Deal, Thin Fish, Head Like A Hole, Ralph Bennett, Dave Murphy, Luke Hurcey, Johnny B Band, Wild Fire, Serpentine, Bullfrog Rata, Blue Smoke, Sam Hunt, Vandrix, Helter Skelter | Music | Woodville | New Zealand | | Mountain Rock | Jon Toogood | |
+| 1992-01-24 | Buddakhan | Music | Wellington | New Zealand | New Carpark | | | |
+| 1992-01-01 | Push Push, The Exponents | Music | Napier | New Zealand | Onekawa Rockgarden | | Jordan Luck | |
+| 1991-12-28 | Ted Clarke, Backdoor Blues | Music | Hastings | New Zealand | Stortford Lodge | | | |
+| 1991-11-14 | Shihad, AC/DC | Music | Wellington | New Zealand | Athletic Park | | Jon Toogood | |
+| 1991-09-27 | Scios, NIHL, Sacrament, Josephine Bewitched, Deliverance | Music | Wellington | New Zealand | Empire Warehouse | | | |
+| 1991-04-10 | Jeff Healey, Midge Marsden | Music | Wellington | New Zealand | St James Theatre | | | |
+| 1986-03-04 | Dire Straits, Satellite Spies | Music | Wellington | New Zealand | Athletic Park | | Mark Knopfler | |

--- a/lib/gig-history.mjs
+++ b/lib/gig-history.mjs
@@ -5,7 +5,7 @@
   data row per gig — see content/GigTracker/README.md for the exact contract.
 */
 
-const COLUMNS = ["date", "performer", "category", "city", "country", "venue", "show", "association"];
+const COLUMNS = ["date", "performer", "category", "city", "country", "venue", "show", "association", "setlistfmId"];
 
 function isSeparatorRow (line) {
   return line.startsWith("|---");

--- a/tests/unit/gig-history.test.mjs
+++ b/tests/unit/gig-history.test.mjs
@@ -6,10 +6,10 @@ const TABLE = [
   "",
   "Some description text.",
   "",
-  "| Date | Show | Category | City | Country | Venue | Notes | Association |",
-  "|---|---|---|---|---|---|---|---|",
-  "| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Hadestown: Teen Edition | Weta |",
-  "| 2026-05-01 | Fat Freddy's Drop | Music | Wellington | New Zealand | Michael Fowler Centre | | |"
+  "| Date | Show | Category | City | Country | Venue | Notes | Association | Setlist.fm ID |",
+  "|---|---|---|---|---|---|---|---|---|",
+  "| 2026-06-27 | Hadestown: Teen Edition | Theatre | Paraparaumu | New Zealand | Coastlands Theatre | Hadestown: Teen Edition | Weta | 8a1b2c3d |",
+  "| 2026-05-01 | Fat Freddy's Drop | Music | Wellington | New Zealand | Michael Fowler Centre | | | |"
 ].join("\n");
 
 describe("gig-history — parseGigHistory", () => {
@@ -24,7 +24,8 @@ describe("gig-history — parseGigHistory", () => {
       country: "New Zealand",
       venue: "Coastlands Theatre",
       show: "Hadestown: Teen Edition",
-      association: "Weta"
+      association: "Weta",
+      setlistfmId: "8a1b2c3d"
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a ninth `Setlist.fm ID` column to `content/GigTracker/gig-history.md`, appended empty on all 494 existing rows.
- Parser (`lib/gig-history.mjs`) now emits it as `setlistfmId` on each gig object.
- The Gig Tracker app (`gig-history.html`) never reads that key — no `<th>`, no filter, not part of the search key list — so nothing rendered on the site changes.
- README updated to document the new column and the "data only" contract.
- Unit test fixture/expectations updated to cover the new column.

Existing rows are deliberately left blank rather than backfilled — see conversation for scope decision. New gigs can carry an ID going forward.

## Test plan
- [x] `npm run test:unit` — 114 passing, coverage still 100% on all four metrics
- [x] `npm run test:headless` (build + smoke) — 49 passing, including the Gig Tracker embed-contract tests
- [x] Verified built `_site/Gig-History/index.html`: `setlistfmId` is present in the baked-in JSON data, but table headers, filters, and the search key list are byte-identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)