### PR TITLE
Fail the build on a gig-history row with the wrong column count

### DIFF
--- a/content/GigTracker/README.md
+++ b/content/GigTracker/README.md
@@ -34,8 +34,10 @@ All nine columns are required on every row (leave a column blank rather than
 omitting it — see the `Notes`, `Association` and `Setlist.fm ID` columns
 above). Free text before the header (a title, a description paragraph) and
 after the table (notes) is ignored by the parser in `lib/gig-history.mjs`;
-only lines starting with `|` after the header count as rows, and a row with
-the wrong number of columns is skipped.
+only lines starting with `|` after the header count as rows. A row with the
+wrong number of columns — too few or too many — fails the build rather than
+being silently dropped, so a mistyped row can't make a gig quietly vanish
+from the site.
 
 `Setlist.fm ID` is data only — the setlist.fm ID for the gig, where one
 exists. It is parsed into each gig object as `setlistfmId` but the app

--- a/content/GigTracker/gig-history.md
+++ b/content/GigTracker/gig-history.md
@@ -69,7 +69,7 @@ Data has been manually improved, validated and some gigs identified in gigs-miss
 | 2019-03-02 | Eminem, Hilltop Hoods | Music | Wellington | New Zealand | Westpac Stadium | | | |
 | 2019-02-23 | Trinity Roots, The Beths, C.W. Stoneking, The Miltones | Music | Paraparaumu | New Zealand | Southward's Car Museum | Coastella | | |
 | 2019-02-06 | Jon Toogood | Music | Wellington | New Zealand | Meow | | | |
-| 2018-11-26 | Whose Line Is It Anyway | Comedy | Wellington | New Zealand | The Opera House | Colin, Brad & Greg From Whose Line Is It Anyway? | |
+| 2018-11-26 | Whose Line Is It Anyway | Comedy | Wellington | New Zealand | The Opera House | Colin, Brad & Greg From Whose Line Is It Anyway? | | |
 | 2018-11-08 | Trinity Roots | Music | Wellington | New Zealand | The Opera House | | | |
 | 2018-10-20 | Shihad, Beastwars, Villainy | Music | Wellington | New Zealand | Shed 6 | Shihad 30 | Jon Toogood | |
 | 2018-10-13 | Don McGlashan | Music | Wellington | New Zealand | Old St Paul's | | | |
@@ -395,7 +395,7 @@ Data has been manually improved, validated and some gigs identified in gigs-miss
 | 2002-04-19 | Tool | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
 | 2001-05-10 | Pantera | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
 | 2000-05-01 | ZZ Top | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
-| 2000-01-21 | Red Hot Chili Peppers, Nine Inch Nails, Foo Fighters, Blink-182, Joe Strummer and the Mescaleros, Shihad, Grinspoon, Spiderbait, Head Like A Hole, Chemical Brothers, Basement Jaxx | Music | Auckland | New Zealand | Mount Smart Stadium | Big Day Out | |
+| 2000-01-21 | Red Hot Chili Peppers, Nine Inch Nails, Foo Fighters, Blink-182, Joe Strummer and the Mescaleros, Shihad, Grinspoon, Spiderbait, Head Like A Hole, Chemical Brothers, Basement Jaxx | Music | Auckland | New Zealand | Mount Smart Stadium | Big Day Out | | |
 | 1999-10-02 | Alanis Morissette | Music | Wellington | New Zealand | Queens Wharf Events Centre | | | |
 | 1999-05-30 | Beastie Boys, DJ Mix Master Mike | Music | Wellington | New Zealand | Wellington Town Hall | | | |
 | 1999-04-17 | Keb' Mo', Paul Ubana Jones | Music | Wellington | New Zealand | State Opera House | | | |

--- a/lib/gig-history.mjs
+++ b/lib/gig-history.mjs
@@ -15,36 +15,43 @@ function isHeaderRow (line) {
   return line.startsWith("| Date");
 }
 
-function parseRow (line) {
-  const cells = line.split("|").map((cell) => cell.trim());
-
-  // A well-formed "| a | b | ... |" line splits into one empty string
-  // before the first "|" and one after the last, plus a cell per column.
-  if (cells.length !== COLUMNS.length + 2) { return null; }
-
-  const fields = cells.slice(1, -1);
-  return Object.fromEntries(COLUMNS.map((name, i) => [name, fields[i]]));
+function splitRow (line) {
+  return line.split("|").map((cell) => cell.trim());
 }
 
 /**
  * Extracts gig rows from the markdown table. Lines before the header, the
  * header and separator rows themselves, and anything after the table (a
- * trailing blank line, notes, EOF) are ignored. A data row with the wrong
- * number of columns is skipped rather than thrown on, since the file is
- * hand-edited.
+ * trailing blank line, notes, EOF) are ignored. A data row whose column
+ * count doesn't match the header's throws rather than being silently
+ * skipped — a hand-edited row with too few or too many columns should fail
+ * the build instead of quietly vanishing from the site.
  */
 export function parseGigHistory (markdown) {
   const lines = markdown.split("\n").map((line) => line.trim());
   const headerIndex = lines.findIndex(isHeaderRow);
   if (headerIndex === -1) { return []; }
 
+  // A well-formed "| a | b | ... |" line splits into one empty string
+  // before the first "|" and one after the last, plus a cell per column.
+  const expectedCells = splitRow(lines[headerIndex]).length;
+
   const rows = [];
-  for (const line of lines.slice(headerIndex + 1)) {
+  for (const [offset, line] of lines.slice(headerIndex + 1).entries()) {
     if (isSeparatorRow(line)) { continue; }
     if (!line.startsWith("|")) { break; }
 
-    const row = parseRow(line);
-    if (row) { rows.push(row); }
+    const cells = splitRow(line);
+    if (cells.length !== expectedCells) {
+      const lineNumber = headerIndex + offset + 2;
+      throw new Error(
+        `gig-history.md line ${lineNumber} has ${cells.length - 2} column(s), ` +
+        `expected ${expectedCells - 2} to match the header row: ${line}`
+      );
+    }
+
+    const fields = cells.slice(1, -1);
+    rows.push(Object.fromEntries(COLUMNS.map((name, i) => [name, fields[i]])));
   }
   return rows;
 }

--- a/tests/unit/gig-history.test.mjs
+++ b/tests/unit/gig-history.test.mjs
@@ -39,9 +39,14 @@ describe("gig-history — parseGigHistory", () => {
     expect(parseGigHistory(withTrailer)).to.have.lengthOf(2);
   });
 
-  it("skips a data row with the wrong number of columns", () => {
+  it("throws on a data row with too few columns", () => {
     const withBadRow = `${TABLE}\n| 2026-01-01 | Missing Columns |`;
-    expect(parseGigHistory(withBadRow)).to.have.lengthOf(2);
+    expect(() => parseGigHistory(withBadRow)).to.throw(/has 2 column\(s\), expected 9/);
+  });
+
+  it("throws on a data row with too many columns", () => {
+    const withBadRow = `${TABLE}\n| 2026-01-01 | Too | Many | Columns | Here | Than | Should | Be | Present | Really |`;
+    expect(() => parseGigHistory(withBadRow)).to.throw(/has 10 column\(s\), expected 9/);
   });
 
   it("returns an empty array when there is no header row", () => {


### PR DESCRIPTION
## Summary
- `parseGigHistory` now compares each data row's column count against the header row's (dynamically, not a hardcoded constant) and throws when they don't match — too few or too many columns.
- This propagates up through `content/_data/gigTrackerApp.mjs` (an Eleventy global data file), so a malformed row aborts the whole `eleventy` build instead of the gig just silently vanishing from the site.
- Fixes a real instance of this bug found while testing: the "Whose Line Is It Anyway" / 2018-11-26 row in `content/GigTracker/gig-history.md` was missing a trailing blank column.
- Updated `content/GigTracker/README.md` to describe the new fail-loud behaviour, replacing the old "wrong column count rows are skipped" note.

## Test plan
- [x] `npm run test:unit` — 115 passing, coverage still 100% on all four metrics
- [x] `npm run build` — confirmed it fails with a clear error/line number on the pre-fix malformed row, and succeeds after fixing it
- [x] `npm run test:smoke` — 49 passing, Gig Tracker embed tests included