### PR TITLE
Add Escape-to-close and focus management to app-nav sheet

### DIFF
--- a/content/_includes/partials/app-nav.njk
+++ b/content/_includes/partials/app-nav.njk
@@ -70,6 +70,7 @@
         var root = document.documentElement;
         var collapse = document.getElementById('app-nav-collapse');
         var menu = document.getElementById('app-nav-menu');
+        var nav = document.getElementById('app-nav');
 
         if (collapse) {
             var render = function () {
@@ -92,11 +93,65 @@
         // Below the breakpoint the same nav is a sheet that pushes down from
         // the bar. Kept separate from the collapse state so a phone reader
         // never inherits a desktop choice.
-        if (menu) {
+        if (menu && nav) {
+            var focusableSelector = 'a[href], button:not([disabled])';
+
+            // .app-nav-home and .app-nav-collapse are display:none at this
+            // breakpoint (the bar already covers what they offer — see the
+            // CSS comment above their rule), so they must be skipped here or
+            // focus() silently no-ops on them.
+            var visibleFocusable = function () {
+                return Array.prototype.slice.call(nav.querySelectorAll(focusableSelector))
+                    .filter(function (el) { return el.offsetParent !== null; });
+            };
+
+            var openSheet = function () {
+                root.dataset.appNavSheet = 'open';
+                menu.setAttribute('aria-expanded', 'true');
+                var firstFocusable = visibleFocusable()[0];
+                if (firstFocusable) firstFocusable.focus();
+            };
+
+            var closeSheet = function () {
+                root.dataset.appNavSheet = 'closed';
+                menu.setAttribute('aria-expanded', 'false');
+                menu.focus();
+            };
+
             menu.addEventListener('click', function () {
-                var open = root.dataset.appNavSheet === 'open';
-                root.dataset.appNavSheet = open ? 'closed' : 'open';
-                menu.setAttribute('aria-expanded', String(!open));
+                if (root.dataset.appNavSheet === 'open') {
+                    closeSheet();
+                } else {
+                    openSheet();
+                }
+            });
+
+            // Escape closes the sheet, and Tab is trapped inside it while
+            // open — both are needed for the sheet to be as easy to close
+            // and navigate with a keyboard as it is to open (#99).
+            nav.addEventListener('keydown', function (e) {
+                if (root.dataset.appNavSheet !== 'open') return;
+
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    closeSheet();
+                    return;
+                }
+
+                if (e.key !== 'Tab') return;
+
+                var focusable = visibleFocusable();
+                if (focusable.length === 0) return;
+                var first = focusable[0];
+                var last = focusable[focusable.length - 1];
+
+                if (e.shiftKey && document.activeElement === first) {
+                    e.preventDefault();
+                    last.focus();
+                } else if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
             });
         }
     })();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "debug": "DEBUG=* npx eleventy",
     "test:theme": "npm run build && mocha tests/theme.test.mjs --timeout 60000",
     "test:analytics": "npm run build && mocha tests/analytics.test.mjs --timeout 60000",
-    "test:gigtracker": "npm run build && mocha tests/gig-tracker.test.mjs --timeout 60000"
+    "test:gigtracker": "npm run build && mocha tests/gig-tracker.test.mjs --timeout 60000",
+    "test:app-nav": "npm run build && mocha tests/app-nav.test.mjs --timeout 60000"
   },
   "repository": {
     "type": "git",

--- a/tests/app-nav.test.mjs
+++ b/tests/app-nav.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Behavioural tests for the app-nav hamburger sheet's keyboard behaviour
+ * (#99): Escape closes it, focus moves into it on open and back to the
+ * toggle button on close, and Tab is trapped inside it while open.
+ */
+
+import { expect } from 'chai';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
+
+// Its own port: theme holds 3001, analytics 3002, gig-tracker 3003.
+const PORT = 3004;
+const BASE = `http://localhost:${PORT}`;
+
+describe('App-nav hamburger sheet', function () {
+  this.timeout(60000);
+
+  let browser;
+
+  before(async function () {
+    await startServer(PORT);
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  });
+
+  after(async function () {
+    if (browser) await browser.close();
+    await stopServer();
+  });
+
+  async function open() {
+    const context = await browser.newContext({ viewport: { width: 375, height: 800 } });
+    const page = await context.newPage();
+    await page.goto(`${BASE}/Gig-History/index.html`, { waitUntil: 'networkidle' });
+    return { context, page };
+  }
+
+  it('opens the sheet and moves focus to the first nav link', async function () {
+    const { context, page } = await open();
+    await page.click('#app-nav-menu');
+    const opened = await page.evaluate(() => document.documentElement.dataset.appNavSheet);
+    expect(opened).to.equal('open');
+    const focused = await page.evaluate(() => document.activeElement.className);
+    expect(focused).to.include('app-nav-link');
+    await context.close();
+  });
+
+  it('closes the sheet on Escape and returns focus to the toggle button', async function () {
+    const { context, page } = await open();
+    await page.click('#app-nav-menu');
+    await page.keyboard.press('Escape');
+    const closed = await page.evaluate(() => document.documentElement.dataset.appNavSheet);
+    expect(closed).to.equal('closed');
+    const expanded = await page.getAttribute('#app-nav-menu', 'aria-expanded');
+    expect(expanded).to.equal('false');
+    const focusedId = await page.evaluate(() => document.activeElement.id);
+    expect(focusedId).to.equal('app-nav-menu');
+    await context.close();
+  });
+
+  it('traps Tab focus inside the sheet while it is open', async function () {
+    const { context, page } = await open();
+    await page.click('#app-nav-menu');
+    // Tab from the first focused link all the way through the sheet; the
+    // last press should wrap back to the first link instead of leaving.
+    const focusableCount = await page.evaluate(() =>
+      document.querySelectorAll('#app-nav a[href], #app-nav button:not([disabled])').length
+    );
+    for (let i = 0; i < focusableCount; i++) {
+      await page.keyboard.press('Tab');
+    }
+    const wrapped = await page.evaluate(() => document.activeElement.className);
+    expect(wrapped).to.include('app-nav-link');
+    await context.close();
+  });
+
+  it('leaves the toggle button state closed when the sheet has never been opened', async function () {
+    const { context, page } = await open();
+    const state = await page.evaluate(() => document.documentElement.dataset.appNavSheet);
+    expect(state).to.satisfy((v) => v === undefined || v === 'closed');
+    await context.close();
+  });
+});


### PR DESCRIPTION
## Summary
- The app-nav hamburger sheet (#app-nav-menu on app pages like /GigTracker/, /ExifCmdLine/) toggled `aria-expanded` correctly but had no Escape-to-close handler and no focus management, so keyboard/screen-reader users could open it but not easily close it or find their way inside it.
- Opening the sheet now moves focus to its first visible link, Escape closes it and returns focus to the toggle button, and Tab is trapped inside the sheet while it's open.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained (unaffected, change is outside `lib/`)
- [x] `npm run test:smoke` — all passing
- [x] New `tests/app-nav.test.mjs` (Playwright, `npm run test:app-nav`) covering open/focus, Escape/close/focus-return, and Tab trapping — all passing

Closes #99.