### PR TITLE
Suppress zero-gig tooltip and add crosshair to stats chart

### DIFF
--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -251,6 +251,12 @@ tbody tr:last-child td {
   fill: transparent;
   cursor: pointer;
 }
+.stats-crosshair {
+  stroke: var(--muted);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  pointer-events: none;
+}
 .stats-tooltip {
   /*
     position: fixed rather than absolute so the tooltip escapes .stats-panel's

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -270,6 +270,7 @@ const CATEGORY_VAR = {
 
 let statsOpen = false;
 let currentStatsBuckets = [];
+let currentStatsLayout = null;
 
 function monthsInRange(rows) {
   if (rows.length === 0) return [];
@@ -366,6 +367,7 @@ function drawStatsChart(buckets) {
   if (buckets.length === 0) {
     svg.innerHTML = `<text x="${W / 2}" y="${H / 2}" text-anchor="middle" class="stats-empty-text">No gigs match these filters.</text>`;
     currentStatsBuckets = [];
+    currentStatsLayout = null;
     return;
   }
 
@@ -414,8 +416,14 @@ function drawStatsChart(buckets) {
 
   parts.push(`<line x1="${marginLeft}" y1="${axisY}" x2="${W - marginRight}" y2="${axisY}" class="stats-axis-line" />`);
 
+  // Hidden until the mousemove handler positions and shows them over a bar
+  // with a non-zero total (#121).
+  parts.push(`<line id="stats-crosshair-x" x1="0" y1="${marginTop}" x2="0" y2="${axisY}" class="stats-crosshair" style="display:none" />`);
+  parts.push(`<line id="stats-crosshair-y" x1="${marginLeft}" y1="0" x2="${W - marginRight}" y2="0" class="stats-crosshair" style="display:none" />`);
+
   svg.innerHTML = parts.join("");
   currentStatsBuckets = buckets;
+  currentStatsLayout = { marginLeft, marginRight, marginTop, axisY, chartH, groupWidth, yMax };
 }
 
 function renderStats(filteredRows) {
@@ -454,13 +462,44 @@ statsToggle.addEventListener("click", () => {
 const statsChartWrap = document.getElementById("stats-chart-wrap");
 const statsTooltip = document.getElementById("stats-tooltip");
 
+function hideCrosshair() {
+  const x = document.getElementById("stats-crosshair-x");
+  const y = document.getElementById("stats-crosshair-y");
+  if (x) x.style.display = "none";
+  if (y) y.style.display = "none";
+}
+
+function showCrosshair(group, bucket) {
+  const x = document.getElementById("stats-crosshair-x");
+  const y = document.getElementById("stats-crosshair-y");
+  if (!x || !y || !currentStatsLayout) return;
+  const { marginTop, axisY, chartH, groupWidth, yMax } = currentStatsLayout;
+  const hitX = Number(group.querySelector(".stats-hit-area").getAttribute("x"));
+  const centerX = hitX + groupWidth / 2;
+  const topY = axisY - (bucket.total / yMax) * chartH;
+
+  x.setAttribute("x1", centerX);
+  x.setAttribute("x2", centerX);
+  x.setAttribute("y1", marginTop);
+  x.setAttribute("y2", axisY);
+  x.style.display = "";
+
+  y.setAttribute("y1", topY);
+  y.setAttribute("y2", topY);
+  y.style.display = "";
+}
+
 statsChartWrap.addEventListener("mousemove", (e) => {
   const group = e.target.closest(".stats-bar-group");
-  if (!group) { statsTooltip.hidden = true; return; }
+  if (!group) { statsTooltip.hidden = true; hideCrosshair(); return; }
   const bucket = currentStatsBuckets.find(b => b.month === group.dataset.month);
-  if (!bucket) { statsTooltip.hidden = true; return; }
+  // A bucket with no gigs still has a hit area (spanning the full column so
+  // hovering next to its neighbours' bars is forgiving), but there is
+  // nothing to show a tooltip or crosshair for (#122).
+  if (!bucket || bucket.total === 0) { statsTooltip.hidden = true; hideCrosshair(); return; }
   statsTooltip.innerHTML = buildTooltipHtml(bucket);
   statsTooltip.hidden = false;
+  showCrosshair(group, bucket);
 
   // Clamp to the viewport (position: fixed is viewport-relative) so the
   // tooltip never runs off the right/bottom edge for bars near either side
@@ -479,7 +518,7 @@ statsChartWrap.addEventListener("mousemove", (e) => {
   statsTooltip.style.top = `${Math.max(margin, top)}px`;
 });
 
-statsChartWrap.addEventListener("mouseleave", () => { statsTooltip.hidden = true; });
+statsChartWrap.addEventListener("mouseleave", () => { statsTooltip.hidden = true; hideCrosshair(); });
 
 // The chart's viewBox tracks its rendered width (see drawStatsChart), so a
 // window resize needs a redraw or the old viewBox stays stretched against

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "debug": "DEBUG=* npx eleventy",
     "test:theme": "npm run build && mocha tests/theme.test.mjs --timeout 60000",
     "test:analytics": "npm run build && mocha tests/analytics.test.mjs --timeout 60000",
-    "test:gigtracker": "npm run build && mocha tests/gig-tracker.test.mjs --timeout 60000"
+    "test:gigtracker": "npm run build && mocha tests/gig-tracker.test.mjs --timeout 60000",
+    "test:gigtracker-stats-chart": "npm run build && mocha tests/gig-tracker-stats-chart.test.mjs --timeout 60000"
   },
   "repository": {
     "type": "git",

--- a/tests/gig-tracker-stats-chart.test.mjs
+++ b/tests/gig-tracker-stats-chart.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Behavioural tests for the Gig Tracker statistics bar chart's hover
+ * feedback: no tooltip for a month with zero gigs (#122), and a crosshair
+ * that tracks the hovered bar (#121).
+ */
+
+import { expect } from 'chai';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
+
+// Its own port: theme 3001, analytics 3002, gig-tracker 3003, app-nav 3004.
+const PORT = 3005;
+const BASE = `http://localhost:${PORT}`;
+
+describe('Gig Tracker statistics chart hover', function () {
+  this.timeout(60000);
+
+  let browser;
+
+  before(async function () {
+    await startServer(PORT);
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  });
+
+  after(async function () {
+    if (browser) await browser.close();
+    await stopServer();
+  });
+
+  async function openWithStatsPanel(page) {
+    await page.goto(`${BASE}/Gig-History/index.html`, { waitUntil: 'networkidle' });
+    await page.click('#stats-toggle');
+    await page.waitForSelector('#stats-panel.stats-panel--open');
+    await page.waitForFunction(() => document.querySelectorAll('#stats-chart .stats-bar-group').length > 0);
+  }
+
+  async function groupTotals(page) {
+    return page.evaluate(() => {
+      const groups = Array.from(document.querySelectorAll('#stats-chart .stats-bar-group'));
+      return groups.map(g => ({
+        month: g.dataset.month,
+        // A group with no gigs renders no <rect> segments beyond the hit area.
+        total: g.querySelectorAll('rect:not(.stats-hit-area)').length > 0 ? 1 : 0
+      }));
+    });
+  }
+
+  async function hoverGroup(page, month) {
+    const box = await page.evaluate((m) => {
+      const group = document.querySelector(`.stats-bar-group[data-month="${m}"] .stats-hit-area`);
+      const rect = group.getBoundingClientRect();
+      return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+    }, month);
+    await page.mouse.move(box.x, box.y);
+  }
+
+  it('shows no tooltip when hovering a month with zero gigs, if one exists', async function () {
+    const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+    const page = await context.newPage();
+    await openWithStatsPanel(page);
+
+    const totals = await groupTotals(page);
+    const zeroMonth = totals.find(t => t.total === 0);
+    if (!zeroMonth) {
+      this.skip(); // the current data has no gap month to exercise this on
+    }
+
+    await hoverGroup(page, zeroMonth.month);
+    const hidden = await page.getAttribute('#stats-tooltip', 'hidden');
+    expect(hidden).to.not.equal(null);
+    await context.close();
+  });
+
+  it('shows a tooltip and crosshair when hovering a month with gigs', async function () {
+    const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+    const page = await context.newPage();
+    await openWithStatsPanel(page);
+
+    const totals = await groupTotals(page);
+    const activeMonth = totals.find(t => t.total > 0);
+    expect(activeMonth, 'expected at least one month with gigs').to.exist;
+
+    await hoverGroup(page, activeMonth.month);
+    const hidden = await page.getAttribute('#stats-tooltip', 'hidden');
+    expect(hidden).to.equal(null);
+
+    const crosshairDisplay = await page.evaluate(() => ({
+      x: document.getElementById('stats-crosshair-x').style.display,
+      y: document.getElementById('stats-crosshair-y').style.display
+    }));
+    expect(crosshairDisplay.x).to.not.equal('none');
+    expect(crosshairDisplay.y).to.not.equal('none');
+    await context.close();
+  });
+
+  it('hides the tooltip and crosshair on mouseleave', async function () {
+    const context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+    const page = await context.newPage();
+    await openWithStatsPanel(page);
+
+    const totals = await groupTotals(page);
+    const activeMonth = totals.find(t => t.total > 0);
+    await hoverGroup(page, activeMonth.month);
+    await page.hover('#stats-title'); // move outside the chart wrap
+    await page.dispatchEvent('#stats-chart-wrap', 'mouseleave');
+
+    const hidden = await page.getAttribute('#stats-tooltip', 'hidden');
+    expect(hidden).to.not.equal(null);
+    const crosshairDisplay = await page.evaluate(() => ({
+      x: document.getElementById('stats-crosshair-x').style.display,
+      y: document.getElementById('stats-crosshair-y').style.display
+    }));
+    expect(crosshairDisplay.x).to.equal('none');
+    expect(crosshairDisplay.y).to.equal('none');
+    await context.close();
+  });
+});


### PR DESCRIPTION
## Summary
- The gig tracker statistics bar chart's tooltip appeared even for a month with zero gigs, since each column's invisible hit area spans the full month width regardless of whether it has a bar. The mousemove handler now skips the tooltip (and the new crosshair) when the hovered bucket's total is 0. (#122)
- Added a crosshair — a dashed vertical line through the hovered bar and a dashed horizontal line at its stacked top — so it's easier to read a bar's value off the y-axis while hovering. It only appears for bars that also show a tooltip. (#121)

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained (unaffected, change is outside `lib/`)
- [x] `npm run test:smoke` — all passing
- [x] `npm run test:gigtracker` — all passing
- [x] `npm run test:visual` — all passing, no baseline changes needed (crosshair is hidden by default in the static baselines)
- [x] New `tests/gig-tracker-stats-chart.test.mjs` (Playwright, `npm run test:gigtracker-stats-chart`) covering: no tooltip on a zero-gig month, tooltip + crosshair shown on a real month, both hidden on mouseleave — all passing

Closes #122. Closes #121.