### PR TITLE
Make Gig Tracker dropdown filters mutually adaptive

### DIFF
--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -76,15 +76,22 @@ function splitPerformers(str) {
   return str.split(",").map(s => s.trim()).filter(Boolean);
 }
 
+function matchesFilterKey(g, key, value) {
+  if (key === "performer") {
+    return splitPerformers(g.performer).includes(value) || splitPerformers(g.association).includes(value);
+  }
+  return g[key] === value;
+}
+
+// Options for a dropdown are drawn from rows matching every *other* active
+// filter (search is deliberately excluded, per #118), so activating one
+// filter narrows the rest without ever invalidating itself.
 function uniqueSorted(key) {
   let rows = GIGS;
-  if (key === "city" && filters.country) {
-    rows = rows.filter(g => g.country === filters.country);
-  }
-  if (key === "venue") {
-    if (filters.country) rows = rows.filter(g => g.country === filters.country);
-    if (filters.city) rows = rows.filter(g => g.city === filters.city);
-  }
+  Object.keys(filters).forEach(otherKey => {
+    if (otherKey === key || !filters[otherKey]) return;
+    rows = rows.filter(g => matchesFilterKey(g, otherKey, filters[otherKey]));
+  });
   const vals = new Set();
   if (key === "performer") {
     rows.forEach(g => {
@@ -102,9 +109,7 @@ function attachFilterListeners() {
     const sel = document.getElementById(filterIds[key]);
     sel.addEventListener("change", () => {
       filters[key] = sel.value;
-      if (key === "country" || key === "city") {
-        populateFilters();
-      }
+      populateFilters();
       render();
       // A <select> keeps matching :focus-visible after a real interaction
       // (unlike a <button>), so the shared focus/active outline (#108)
@@ -139,10 +144,7 @@ function applyFilters(rows) {
   return rows.filter(g => {
     const matchesDropdowns = Object.keys(filters).every(key => {
       if (!filters[key]) return true;
-      if (key === "performer") {
-        return splitPerformers(g.performer).includes(filters[key]) || splitPerformers(g.association).includes(filters[key]);
-      }
-      return g[key] === filters[key];
+      return matchesFilterKey(g, key, filters[key]);
     });
     if (!matchesDropdowns) return false;
     if (!searchTerm) return true;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:theme": "npm run build && mocha tests/theme.test.mjs --timeout 60000",
     "test:analytics": "npm run build && mocha tests/analytics.test.mjs --timeout 60000",
     "test:gigtracker": "npm run build && mocha tests/gig-tracker.test.mjs --timeout 60000",
+    "test:gigtracker-filter-adaptation": "npm run build && mocha tests/gig-tracker-filter-adaptation.test.mjs --timeout 60000",
     "test:gigtracker-stats-chart": "npm run build && mocha tests/gig-tracker-stats-chart.test.mjs --timeout 60000",
     "test:app-nav": "npm run build && mocha tests/app-nav.test.mjs --timeout 60000"
   },

--- a/tests/gig-tracker-filter-adaptation.test.mjs
+++ b/tests/gig-tracker-filter-adaptation.test.mjs
@@ -1,0 +1,107 @@
+/**
+ * Behavioural tests for Gig Tracker's mutual dropdown filtering (#118).
+ *
+ * When a dropdown filter is active, the *other* dropdowns should only offer
+ * values that are actually reachable given the active filter(s) — e.g.
+ * picking a country should narrow the city list to cities in that country.
+ * The active filter's own dropdown must keep its full option list, and
+ * clearing filters must restore every dropdown to its full list.
+ */
+
+import { expect } from 'chai';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
+
+// Its own port: theme 3001, analytics 3002, visual 3000, active-indicator 3003.
+const PORT = 3004;
+const BASE = `http://localhost:${PORT}`;
+
+describe('Gig Tracker adaptive dropdown filters', function () {
+  this.timeout(60000);
+
+  let browser;
+  let context;
+  let page;
+
+  before(async function () {
+    await startServer(PORT);
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  });
+
+  after(async function () {
+    if (browser) await browser.close();
+    await stopServer();
+  });
+
+  beforeEach(async function () {
+    context = await browser.newContext({ viewport: { width: 1200, height: 800 } });
+    page = await context.newPage();
+    await page.goto(`${BASE}/Gig-History/index.html`, { waitUntil: 'networkidle' });
+  });
+
+  afterEach(async function () {
+    await context.close();
+  });
+
+  const optionsOf = (page, selector) =>
+    page.$eval(selector, (sel) => Array.from(sel.options).map((o) => o.value).filter(Boolean));
+
+  // Real gig-history data: Australia has gigs in exactly one city (Sydney),
+  // which makes it a deterministic fixture for narrowing assertions without
+  // needing to hardcode the whole dataset's shape.
+  const SINGLE_CITY_COUNTRY = 'Australia';
+  const SINGLE_CITY_COUNTRY_CITY = 'Sydney';
+
+  it('narrows the city, venue and show dropdowns when a country with one city is selected', async function () {
+    const fullCities = await optionsOf(page, '#f-city');
+    expect(fullCities.length).to.be.greaterThan(1);
+
+    await page.selectOption('#f-country', SINGLE_CITY_COUNTRY);
+
+    const narrowedCities = await optionsOf(page, '#f-city');
+    expect(narrowedCities).to.deep.equal([SINGLE_CITY_COUNTRY_CITY]);
+
+    const rowVenues = await page.$$eval('#tbody tr', (rows) =>
+      rows.map((r) => r.children[5].textContent.trim())
+    );
+    const venueOptions = await optionsOf(page, '#f-venue');
+    expect(venueOptions.every((v) => rowVenues.includes(v))).to.be.true;
+  });
+
+  it('keeps the active filter\'s own dropdown showing its full option list', async function () {
+    const fullCountries = await optionsOf(page, '#f-country');
+
+    await page.selectOption('#f-country', SINGLE_CITY_COUNTRY);
+
+    const countriesAfter = await optionsOf(page, '#f-country');
+    expect(countriesAfter).to.deep.equal(fullCountries);
+  });
+
+  it('narrows the country dropdown when a city is selected (reverse relationship)', async function () {
+    await page.selectOption('#f-city', SINGLE_CITY_COUNTRY_CITY);
+
+    const countries = await optionsOf(page, '#f-country');
+    expect(countries).to.deep.equal([SINGLE_CITY_COUNTRY]);
+  });
+
+  it('restores full option lists on every dropdown after Clear filters', async function () {
+    const fullCities = await optionsOf(page, '#f-city');
+    const fullVenues = await optionsOf(page, '#f-venue');
+
+    await page.selectOption('#f-country', SINGLE_CITY_COUNTRY);
+    expect(await optionsOf(page, '#f-city')).to.not.deep.equal(fullCities);
+
+    await page.click('#reset');
+
+    expect(await optionsOf(page, '#f-city')).to.deep.equal(fullCities);
+    expect(await optionsOf(page, '#f-venue')).to.deep.equal(fullVenues);
+  });
+
+  it('leaves the search field independent of dropdown option narrowing', async function () {
+    const fullCountries = await optionsOf(page, '#f-country');
+
+    await page.fill('#search', SINGLE_CITY_COUNTRY_CITY);
+
+    expect(await optionsOf(page, '#f-country')).to.deep.equal(fullCountries);
+  });
+});

--- a/tests/gig-tracker.test.mjs
+++ b/tests/gig-tracker.test.mjs
@@ -107,14 +107,24 @@ describe('Gig Tracker filter active indicator', function () {
       it('clears the indicator when filters are reset', async function () {
         const { context, page } = await open(colorScheme);
 
-        const baseline = await outlineOf(page, '#f-performer');
+        // Each control's own resting style is the baseline — a select and
+        // the reset button rest at different colours by design (--text vs
+        // --muted), so this must not compare one control's post-reset style
+        // against another's baseline.
+        const performerBaseline = await outlineOf(page, '#f-performer');
+        const resetBaseline = await outlineOf(page, '#reset');
         await page.selectOption('#f-performer', { index: 1 });
-        expect(await outlineOf(page, '#f-performer'), 'active after selecting').to.not.equal(baseline);
-        expect(await outlineOf(page, '#reset'), 'reset active after selecting').to.not.equal(baseline);
+        expect(await outlineOf(page, '#f-performer'), 'active after selecting').to.not.equal(performerBaseline);
+        expect(await outlineOf(page, '#reset'), 'reset active after selecting').to.not.equal(resetBaseline);
 
         await page.click('#reset');
-        expect(await outlineOf(page, '#f-performer'), 'inactive after reset').to.equal(baseline);
-        expect(await outlineOf(page, '#reset'), 'reset inactive after reset').to.equal(baseline);
+        // Selecting a performer narrows the other dropdowns (#118), which
+        // can change their rendered width and shift the reset button out
+        // from under the pointer when clicked — move away so :hover can't
+        // leak into this reading.
+        await page.mouse.move(0, 0);
+        expect(await outlineOf(page, '#f-performer'), 'inactive after reset').to.equal(performerBaseline);
+        expect(await outlineOf(page, '#reset'), 'reset inactive after reset').to.equal(resetBaseline);
 
         await context.close();
       });


### PR DESCRIPTION
## Summary
- Country, city, venue, show and category dropdown filters now narrow each other: a dropdown's options are computed from rows matching every *other* active filter, so activating one only offers values that are actually reachable.
- Search remains independent of dropdown narrowing, and clicking a hyperlinked value in a table row is unchanged.
- An active filter's own dropdown always keeps its full option list.

Closes #118.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained (unaffected, this change is outside `lib/`)
- [x] `npm run test:smoke`
- [x] `npm run test:gigtracker` (existing active-indicator suite — fixed one assertion that was inadvertently relying on a mouse-hover artifact this change's layout shift exposes)
- [x] `npm run test:gigtracker-filter-adaptation` (new suite covering the adaptive behaviour, using real gig-history.md data)
- [ ] Note: `npm run test:gigtracker-stats-chart` has one pre-existing failing test unrelated to this change (fails identically on `master`)