### PR TITLE
Blur stats toggle button on close so mobile taps don't stick

### DIFF
--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -458,6 +458,11 @@ statsToggle.addEventListener("click", () => {
   } else {
     statsPanel.classList.remove("stats-panel--open");
     statsPanel.addEventListener("transitionend", hideStatsPanelIfClosed, { once: true });
+    // Touch taps leave the button matching :focus-visible longer than a
+    // mouse click does, so on mobile the shared focus/active outline (#108)
+    // stuck showing after close. Blurring after commit clears it, matching
+    // how the filter <select>s already behave (see attachFilterListeners).
+    statsToggle.blur();
   }
 });
 

--- a/tests/gig-tracker-stats-toggle.test.mjs
+++ b/tests/gig-tracker-stats-toggle.test.mjs
@@ -1,0 +1,60 @@
+/**
+ * Behavioural test for the Gig Tracker statistics toggle button's active
+ * state (#126). Closing the panel already removes .is-active, but a touch
+ * tap (unlike a mouse click) can leave the button matching :focus-visible
+ * afterwards, so the shared focus/active outline stayed showing on mobile.
+ * The fix blurs the button on close, mirroring how the filter <select>s
+ * already behave (see gig-tracker.test.mjs).
+ */
+
+import { expect } from 'chai';
+import { chromium } from 'playwright';
+import { startServer, stopServer } from './utils/http-server.mjs';
+
+// Its own port: theme 3001, analytics 3002, gig-tracker 3003, app-nav/filter
+// adaptation 3004, gig-tracker stats chart 3005.
+const PORT = 3006;
+const BASE = `http://localhost:${PORT}`;
+
+describe('Gig Tracker statistics toggle active state', function () {
+  this.timeout(60000);
+
+  let browser;
+
+  before(async function () {
+    await startServer(PORT);
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+  });
+
+  after(async function () {
+    if (browser) await browser.close();
+    await stopServer();
+  });
+
+  it('loses focus and .is-active when closed by a touch tap', async function () {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true
+    });
+    const page = await context.newPage();
+    await page.goto(`${BASE}/Gig-History/index.html`, { waitUntil: 'networkidle' });
+
+    await page.tap('#stats-toggle');
+    await page.waitForSelector('#stats-panel.stats-panel--open');
+    expect(await page.evaluate(() => document.getElementById('stats-toggle').classList.contains('is-active')))
+      .to.equal(true);
+
+    await page.tap('#stats-toggle');
+    await page.waitForSelector('#stats-panel', { state: 'hidden' });
+
+    const state = await page.evaluate(() => ({
+      isActive: document.getElementById('stats-toggle').classList.contains('is-active'),
+      isFocused: document.activeElement === document.getElementById('stats-toggle')
+    }));
+    expect(state.isActive, 'is-active removed after closing').to.equal(false);
+    expect(state.isFocused, 'button blurred after closing').to.equal(false);
+
+    await context.close();
+  });
+});


### PR DESCRIPTION
## Summary
- On mobile the statistics toggle button kept its active/focus outline after tapping it closed, while the same interaction worked correctly with a mouse click on desktop.
- The filter `<select>`s already blur themselves after committing a value for exactly this reason (`sel.blur()` in `attachFilterListeners`); the stats toggle button just never got the equivalent call.
- Added `statsToggle.blur()` when the panel closes, and a Playwright test that opens/closes the panel with `page.tap()` (touch + mobile viewport) and asserts both `.is-active` and focus are cleared.

Closes #126.

## Test plan
- [x] `npm run test:unit` — 115 passing, coverage still 100%
- [x] `npm run test:smoke` — 49 passing
- [x] New test fails against pre-fix code (confirmed by stashing the fix) and passes after
- [x] Full gig-tracker regression suite (`gig-tracker*.test.mjs`) — 19 passing, no regressions