### PR TITLE
Scope the filter bar's hover styling to hover-capable pointers

### DIFF
--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -57,12 +57,17 @@ h1 {
   cursor: pointer;
   color: var(--muted);
 }
-.filters button:hover,
 .filters button.is-active {
   color: var(--text);
 }
-.filters button:hover {
-  border-color: var(--accent);
+@media (hover: hover) {
+  /* Real pointers only. Touch leaves an element matching :hover until
+     something else is tapped so an unscoped rule left the stats toggle
+     with a stray accent border after the panel closed (issue 132). */
+  .filters button:hover {
+    color: var(--text);
+    border-color: var(--accent);
+  }
 }
 /*
   .is-active marks a control that currently has a non-default value (a filter

--- a/tests/gig-tracker-stats-toggle.test.mjs
+++ b/tests/gig-tracker-stats-toggle.test.mjs
@@ -57,4 +57,33 @@ describe('Gig Tracker statistics toggle active state', function () {
 
     await context.close();
   });
+
+  it('does not leave a stuck accent border from sticky mobile :hover (#132)', async function () {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      isMobile: true
+    });
+    const page = await context.newPage();
+    await page.goto(`${BASE}/Gig-History/index.html`, { waitUntil: 'networkidle' });
+
+    // This emulated touch context has no hover-capable pointer, matching the
+    // real mobile browsers where a tap leaves the tapped element matching
+    // :hover indefinitely.
+    expect(await page.evaluate(() => matchMedia('(hover: hover)').matches)).to.equal(false);
+
+    const borderColor = () => page.evaluate(() =>
+      getComputedStyle(document.getElementById('stats-toggle')).borderColor);
+    const defaultBorderColor = await borderColor();
+
+    await page.tap('#stats-toggle');
+    await page.waitForSelector('#stats-panel.stats-panel--open');
+    await page.tap('#stats-toggle');
+    await page.waitForSelector('#stats-panel', { state: 'hidden' });
+
+    expect(await borderColor(), 'border reverts to default, no lingering hover tint')
+      .to.equal(defaultBorderColor);
+
+    await context.close();
+  });
 });


### PR DESCRIPTION
## Summary
- PR #131 blurred the stats toggle on close, but on mobile the button still showed a second, stuck active indicator: a touch tap leaves the tapped element matching `:hover` indefinitely (no `mouseleave` on touch), so the unscoped `.filters button:hover { border-color: var(--accent); }` rule kept the accent border after the panel closed, on top of the button's legitimate `.is-active` outline.
- Scoped that hover rule with `@media (hover: hover)` so it only applies on real hover-capable pointers, matching the "Clear filters" button, which never picks up this stray border.

Closes #132.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained
- [x] `npm run test:headless`
- [x] New regression test in `tests/gig-tracker-stats-toggle.test.mjs` — reproduces the stuck border in a touch context, fails against the pre-fix CSS, passes with the fix
- [x] `npm run test:gigtracker` (existing active-indicator suite, unaffected — desktop hover still works)
- [x] `npm run test:gigtracker-filter-adaptation`
- [x] `npm run test:visual` — no baseline changes (default rendering unchanged)