### PR TITLE
Disable the stats chart tooltip and crosshair at the mobile breakpoint

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "serve"],
       "port": 8080
+    },
+    {
+      "name": "serve-review",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["eleventy", "--serve", "--port=8081"],
+      "port": 8081
     }
   ]
 }

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -470,6 +470,10 @@ statsToggle.addEventListener("click", () => {
 
 const statsChartWrap = document.getElementById("stats-chart-wrap");
 const statsTooltip = document.getElementById("stats-tooltip");
+// Matches gig-history.css's mobile breakpoint. Disabled at that width for now
+// (#135) — the tooltip/crosshair overlay gets crowded on a chart with lots of
+// gigs in a wide date range; it'll come back reworked for mobile later.
+const statsMobileQuery = window.matchMedia("(max-width: 47.999em)");
 
 function hideCrosshair() {
   const x = document.getElementById("stats-crosshair-x");
@@ -499,6 +503,7 @@ function showCrosshair(group, bucket) {
 }
 
 statsChartWrap.addEventListener("mousemove", (e) => {
+  if (statsMobileQuery.matches) { statsTooltip.hidden = true; hideCrosshair(); return; }
   const group = e.target.closest(".stats-bar-group");
   if (!group) { statsTooltip.hidden = true; hideCrosshair(); return; }
   const bucket = currentStatsBuckets.find(b => b.month === group.dataset.month);

--- a/tests/gig-tracker-stats-chart.test.mjs
+++ b/tests/gig-tracker-stats-chart.test.mjs
@@ -114,4 +114,26 @@ describe('Gig Tracker statistics chart hover', function () {
     expect(crosshairDisplay.y).to.equal('none');
     await context.close();
   });
+
+  it('shows no tooltip or crosshair at the mobile breakpoint (#135)', async function () {
+    const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+    const page = await context.newPage();
+    await openWithStatsPanel(page);
+
+    const totals = await groupTotals(page);
+    const activeMonth = totals.find(t => t.total > 0);
+    expect(activeMonth, 'expected at least one month with gigs').to.exist;
+
+    await hoverGroup(page, activeMonth.month);
+    const hidden = await page.getAttribute('#stats-tooltip', 'hidden');
+    expect(hidden).to.not.equal(null);
+
+    const crosshairDisplay = await page.evaluate(() => ({
+      x: document.getElementById('stats-crosshair-x').style.display,
+      y: document.getElementById('stats-crosshair-y').style.display
+    }));
+    expect(crosshairDisplay.x).to.equal('none');
+    expect(crosshairDisplay.y).to.equal('none');
+    await context.close();
+  });
 });


### PR DESCRIPTION
## Summary
- The hover tooltip and crosshair overlay on the gig tracker's stats bar chart is now disabled at the mobile breakpoint (`max-width: 47.999em`, matching `gig-history.css`) — it gets crowded on a chart with lots of gigs across a wide date range on small screens.
- The functionality isn't removed, just gated behind a `matchMedia` check in the chart's `mousemove` handler, so it comes back automatically at desktop widths. A future issue will rework it for mobile rather than just re-enabling it.
- Desktop behaviour is untouched.

Closes #135.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained (unaffected, outside `lib/`)
- [x] `npm run test:headless`
- [x] New regression test in `tests/gig-tracker-stats-chart.test.mjs` — hovers a bar at a 390px viewport and asserts the tooltip/crosshair stay hidden; fails without the fix, passes with it
- [x] `npm run test:gigtracker`, `test:gigtracker-stats-toggle`, `test:gigtracker-filter-adaptation` — unaffected
- Note: `shows a tooltip and crosshair when hovering a month with gigs` (desktop) is flaky pre-existing (documented in #128's PR description as failing identically on master) — reproduced the flake with this change reverted too, so it's unrelated to this fix