### PR TITLE
Drop 'unsafe-inline' from the CSP by hashing inline blocks at build time

### DIFF
--- a/content/_includes/partials/head.njk
+++ b/content/_includes/partials/head.njk
@@ -72,10 +72,19 @@
   can't carry frame-ancestors (browsers ignore it there), and headers like
   X-Frame-Options/Permissions-Policy have no meta-tag form at all — those
   stay unset until the site sits behind a proxy/CDN that can inject them.
-  'unsafe-inline' is still needed by a handful of un-nonced inline
-  <script>/<style> blocks (this file, analytics.njk, app-nav.njk,
-  theme-toggle.njk, and the appInlineStyles block above) — tracked as a
-  follow-up issue to drop 'unsafe-inline' once those are nonced/hashed.
+
+  'unsafe-inline' below is a placeholder, not the shipped policy. There is
+  no per-request templating on a static site, so nonces aren't viable — the
+  csp-hash build transform (lib/csp-hash.mjs) replaces it on every page with
+  sha256 hash sources computed from that page's own rendered inline
+  <script>/<style> blocks, which is why it must stay textually present here
+  for the transform to find and replace (#100).
+
+  style-src keeps 'unsafe-inline' on the one page (the embedded Gig Tracker)
+  that sets `style="..."` attributes at runtime with colours computed on the
+  fly — hash sources cannot cover an attribute value that isn't known ahead
+  of time. The transform detects this per page from the rendered HTML, so it
+  is not hardcoded to a specific route.
 #}
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://*.posthog.com https://*.i.posthog.com https://*.flickr.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.staticflickr.com https://www.setlist.fm; font-src 'self'; connect-src 'self' https://*.posthog.com https://*.i.posthog.com; media-src 'self' https://*.cloudfront.net; frame-src https://*.flickr.com; form-action 'self' https://adrianparker.us6.list-manage.com; object-src 'none'; base-uri 'self';">
 <meta name="referrer" content="strict-origin-when-cross-origin">

--- a/content/_includes/partials/subscribe-form.njk
+++ b/content/_includes/partials/subscribe-form.njk
@@ -8,7 +8,7 @@
             <label for="mce-EMAIL">Never miss a post - subscribe&colon;&nbsp;</label>
             <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL"
                 placeholder="email address" required>
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text"
+            <div class="subscribe-honeypot" aria-hidden="true"><input type="text"
                     name="b_03ecfd735d95e029717463a19_0a7baede86" tabindex="-1" value=""></div>
             <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe"
                 class="button subscribe_button">

--- a/content/posts/Last-Ever-Last-Ever.md
+++ b/content/posts/Last-Ever-Last-Ever.md
@@ -177,7 +177,7 @@ We held our breaths. Surely that was it?
 
 Hell no. They kept going. And we loved it more than anything. Check out the setlist:
 
-<img src="https://www.setlist.fm/widgets/setlist-image-v1?id=2358f4bb" alt="Shihad Setlist Meow Nui, Wellington, New Zealand 2025, LOUD FOREVER" style="border: 0;" />
+<img src="https://www.setlist.fm/widgets/setlist-image-v1?id=2358f4bb" alt="Shihad Setlist Meow Nui, Wellington, New Zealand 2025, LOUD FOREVER" />
 
 They played all of their own favourites. 
 

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -3,6 +3,7 @@ import pluginRss from "@11ty/eleventy-plugin-rss";
 import { markdownLibrary, renderMarkdown, readableDate, isoDate, limit } from "./lib/filters.mjs";
 import { recentPosts, recentGigs, homePagePosts } from "./lib/collections.mjs";
 import { imageShortcode, videoShortcode } from "./lib/shortcodes.mjs";
+import { injectCspHashes } from "./lib/csp-hash.mjs";
 
 export default function (eleventyConfig) {
 
@@ -92,6 +93,17 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addShortcode("image", imageShortcode);
   eleventyConfig.addShortcode("video", videoShortcode);
+
+  /*
+    Runs on the fully rendered HTML of each page, not the templates, so it
+    catches every inline <script>/<style> block regardless of which partial
+    produced it — including ones that vary per page, like the embedded Gig
+    Tracker's script and the appInlineStyles block (#100).
+  */
+  eleventyConfig.addTransform("csp-hash", function (content) {
+    if (!this.page.outputPath || !this.page.outputPath.endsWith(".html")) return content;
+    return injectCspHashes(content);
+  });
 
   return {
     dir: {

--- a/lib/csp-hash.mjs
+++ b/lib/csp-hash.mjs
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+
+/*
+  Replaces 'unsafe-inline' in the page's CSP meta tag with sha256 hashes of
+  that page's own inline <script>/<style> blocks, computed from the final
+  rendered HTML.
+
+  Working from the rendered output rather than the source templates is what
+  makes this correct for content injected per page — the appInlineStyles
+  <style> block in head.njk, and the embedded Gig Tracker's own <script>,
+  both vary by page and cannot be hashed once for the whole site (see #100).
+
+  A hash source only satisfies elements with a byte-identical body, so a tag
+  with a src (an external script) has nothing to hash and is left alone —
+  it is already covered by the CSP's host list, not by 'unsafe-inline'.
+*/
+
+const CSP_META = /(<meta http-equiv="Content-Security-Policy" content=")([^"]*)("[^>]*>)/;
+const SCRIPT_BLOCK = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const STYLE_BLOCK = /<style\b([^>]*)>([\s\S]*?)<\/style>/gi;
+const HAS_SRC = /\bsrc\s*=/i;
+const STYLE_ATTRIBUTE = /\bstyle\s*=\s*["']/i;
+
+function hash(content) {
+  return `'sha256-${createHash("sha256").update(content, "utf8").digest("base64")}'`;
+}
+
+/**
+ * The sha256 hash sources for every inline (no-src) <script> and <style>
+ * block in the given HTML, each appearing once regardless of repeats.
+ */
+export function extractInlineHashes(html) {
+  const scriptHashes = new Set();
+  const styleHashes = new Set();
+
+  for (const [, attrs, content] of html.matchAll(SCRIPT_BLOCK)) {
+    if (HAS_SRC.test(attrs) || content === "") continue;
+    scriptHashes.add(hash(content));
+  }
+
+  for (const [, , content] of html.matchAll(STYLE_BLOCK)) {
+    if (content === "") continue;
+    styleHashes.add(hash(content));
+  }
+
+  return {
+    scriptHashes: [...scriptHashes],
+    styleHashes: [...styleHashes]
+  };
+}
+
+/**
+ * Swaps 'unsafe-inline' for the given hash sources within one CSP directive
+ * (e.g. "'self' 'unsafe-inline' https://example.com"). Directives without
+ * 'unsafe-inline' are returned unchanged — img-src and friends never had it.
+ */
+function replaceUnsafeInline(directiveValue, hashes) {
+  if (!directiveValue.includes("'unsafe-inline'")) return directiveValue;
+  const sources = directiveValue
+    .split(" ")
+    .filter((source) => source !== "'unsafe-inline'")
+    .concat(hashes);
+  return sources.join(" ");
+}
+
+/**
+ * A hash source only satisfies a <style> element with byte-identical
+ * content — the CSP spec explicitly excludes the `style="..."` attribute
+ * from hash matching (that needs the separate 'unsafe-hashes' keyword, and
+ * even then only for a value known ahead of time). The embedded Gig Tracker
+ * sets `style` attributes with colours computed at runtime, so there is no
+ * fixed value to hash. Detecting that from the rendered HTML — rather than
+ * hardcoding which page it is — means any future inline style attribute
+ * gets the same, correct, conservative treatment automatically (#100).
+ */
+function needsUnsafeInlineForStyleAttributes(html) {
+  return STYLE_ATTRIBUTE.test(html);
+}
+
+/**
+ * Rewrites one page's CSP meta tag in place: 'unsafe-inline' on script-src
+ * is always replaced by hash sources for that page's own inline scripts.
+ * style-src gets the same treatment unless the page also uses `style="..."`
+ * attributes, which hashes cannot cover — those pages keep 'unsafe-inline'
+ * on style-src. Pages with no CSP meta tag (there are none currently, but a
+ * future one) are returned unchanged.
+ */
+export function injectCspHashes(html) {
+  const match = CSP_META.exec(html);
+  if (!match) return html;
+
+  const { scriptHashes, styleHashes } = extractInlineHashes(html);
+  const keepStyleUnsafeInline = needsUnsafeInlineForStyleAttributes(html);
+  const [, prefix, content, suffix] = match;
+
+  const newContent = content
+    .split(";")
+    .map((directive) => {
+      const [, leading, trimmed] = directive.match(/^(\s*)(.*)$/);
+      if (trimmed.startsWith("script-src ")) {
+        return leading + replaceUnsafeInline(trimmed, scriptHashes);
+      }
+      if (trimmed.startsWith("style-src ") && !keepStyleUnsafeInline) {
+        return leading + replaceUnsafeInline(trimmed, styleHashes);
+      }
+      return directive;
+    })
+    .join(";");
+
+  return html.slice(0, match.index) + prefix + newContent + suffix + html.slice(match.index + match[0].length);
+}

--- a/lib/filters.mjs
+++ b/lib/filters.mjs
@@ -2,10 +2,33 @@ import markdownIt from "markdown-it";
 import markdownItFootnote from "markdown-it-footnote";
 
 /**
+ * markdown-it's table rule renders column alignment (`:---`, `---:`, `:---:`)
+ * as a `style="text-align:…"` attribute directly on each `<th>`/`<td>`. That
+ * is an inline style attribute, which the site's CSP cannot cover with a
+ * build-time hash (see lib/csp-hash.mjs) — only a fixed, pre-known value can
+ * be hashed, and every table's cells differ. Rewriting it to a class here,
+ * once, keeps markdown table alignment working without weakening the CSP
+ * for every post that happens to use one (#100). The three classes this
+ * produces (ta-left/ta-right/ta-center) are styled in static/index.css.
+ */
+function tableAlignmentClasses(state) {
+  for (const token of state.tokens) {
+    if (token.type !== "th_open" && token.type !== "td_open") continue;
+    const style = token.attrGet("style");
+    if (!style) continue;
+    const align = style.replace("text-align:", "");
+    token.attrSet("class", `ta-${align}`);
+    token.attrs = token.attrs.filter(([name]) => name !== "style");
+  }
+}
+
+/**
  * The site's markdown renderer. Shared by the `md` filter and by the
  * library Eleventy uses for .md files, so both behave identically.
  */
 export const markdownLibrary = markdownIt({ html: true }).use(markdownItFootnote);
+
+markdownLibrary.core.ruler.push("table-alignment-classes", tableAlignmentClasses);
 
 /**
  * Renders a markdown string to HTML in place. Exposed as the `md` filter so

--- a/static/index.css
+++ b/static/index.css
@@ -639,6 +639,25 @@ figure {
   mask: url('/img/external-link.svg') no-repeat center / contain;
 }
 
+/* Mailchimp's bot honeypot field — kept present for screen readers to skip via aria-hidden, but off-screen for everyone else. */
+.subscribe-honeypot {
+  position: absolute;
+  left: -5000px;
+}
+
+/* Column alignment for markdown tables — see lib/filters.mjs's table-alignment-classes rule. */
+.ta-left {
+  text-align: left;
+}
+
+.ta-right {
+  text-align: right;
+}
+
+.ta-center {
+  text-align: center;
+}
+
 .subscribe_button {
   background-color: var(--color-button-bg);
   color: var(--color-button-text);

--- a/tests/unit/csp-hash.test.mjs
+++ b/tests/unit/csp-hash.test.mjs
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+import { createHash } from "node:crypto";
+import { extractInlineHashes, injectCspHashes } from "../../lib/csp-hash.mjs";
+
+function sriHash(content) {
+  return `'sha256-${createHash("sha256").update(content, "utf8").digest("base64")}'`;
+}
+
+const CSP_HTML = (directives) =>
+  `<head><meta http-equiv="Content-Security-Policy" content="${directives}"></head>`;
+
+describe("csp-hash — extractInlineHashes", () => {
+  it("hashes an inline script's exact content", () => {
+    const { scriptHashes } = extractInlineHashes("<script>var x = 1;</script>");
+    expect(scriptHashes).to.deep.equal([sriHash("var x = 1;")]);
+  });
+
+  it("hashes an inline style's exact content", () => {
+    const { styleHashes } = extractInlineHashes("<style>.a{color:red}</style>");
+    expect(styleHashes).to.deep.equal([sriHash(".a{color:red}")]);
+  });
+
+  it("ignores a script with a src attribute", () => {
+    const { scriptHashes } = extractInlineHashes('<script src="/app.js"></script>');
+    expect(scriptHashes).to.deep.equal([]);
+  });
+
+  it("ignores an empty inline script", () => {
+    const { scriptHashes } = extractInlineHashes("<script></script>");
+    expect(scriptHashes).to.deep.equal([]);
+  });
+
+  it("ignores an empty inline style", () => {
+    const { styleHashes } = extractInlineHashes("<style></style>");
+    expect(styleHashes).to.deep.equal([]);
+  });
+
+  it("dedupes repeated identical blocks", () => {
+    const { scriptHashes } = extractInlineHashes("<script>x()</script><script>x()</script>");
+    expect(scriptHashes).to.have.lengthOf(1);
+  });
+
+  it("hashes scripts and styles with attributes on the tag", () => {
+    const { scriptHashes, styleHashes } = extractInlineHashes(
+      '<script type="text/javascript">a()</script><style media="screen">.b{}</style>'
+    );
+    expect(scriptHashes).to.deep.equal([sriHash("a()")]);
+    expect(styleHashes).to.deep.equal([sriHash(".b{}")]);
+  });
+
+  it("collects several distinct blocks", () => {
+    const { scriptHashes } = extractInlineHashes("<script>a()</script><script>b()</script>");
+    expect(scriptHashes).to.have.lengthOf(2);
+  });
+});
+
+describe("csp-hash — injectCspHashes", () => {
+  it("replaces 'unsafe-inline' on script-src with the page's script hashes", () => {
+    const html =
+      CSP_HTML("script-src 'self' 'unsafe-inline'") + "<script>var x = 1;</script>";
+    const out = injectCspHashes(html);
+    expect(out).to.contain(`script-src 'self' ${sriHash("var x = 1;")}`);
+    expect(out).to.not.contain("'unsafe-inline'");
+  });
+
+  it("replaces 'unsafe-inline' on style-src with the page's style hashes", () => {
+    const html = CSP_HTML("style-src 'self' 'unsafe-inline'") + "<style>.a{}</style>";
+    const out = injectCspHashes(html);
+    expect(out).to.contain(`style-src 'self' ${sriHash(".a{}")}`);
+    expect(out).to.not.contain("'unsafe-inline'");
+  });
+
+  it("leaves other directives untouched", () => {
+    const html = CSP_HTML("default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self'");
+    const out = injectCspHashes(html);
+    expect(out).to.contain("default-src 'self'");
+    expect(out).to.contain("img-src 'self'");
+  });
+
+  it("only hashes that page's own inline blocks, not another page's", () => {
+    const pageA = CSP_HTML("script-src 'self' 'unsafe-inline'") + "<script>a()</script>";
+    const pageB = CSP_HTML("script-src 'self' 'unsafe-inline'") + "<script>b()</script>";
+    expect(injectCspHashes(pageA)).to.contain(sriHash("a()"));
+    expect(injectCspHashes(pageA)).to.not.contain(sriHash("b()"));
+    expect(injectCspHashes(pageB)).to.contain(sriHash("b()"));
+  });
+
+  it("leaves a directive with no 'unsafe-inline' unchanged", () => {
+    const html = CSP_HTML("script-src 'self' https://example.com");
+    const out = injectCspHashes(html);
+    expect(out).to.contain("script-src 'self' https://example.com");
+  });
+
+  it("returns html unchanged when there is no CSP meta tag", () => {
+    const html = "<head><title>No CSP</title></head><script>x()</script>";
+    expect(injectCspHashes(html)).to.equal(html);
+  });
+
+  it("keeps 'unsafe-inline' on style-src when the page has a style attribute, since hashes cannot cover attribute values", () => {
+    const html =
+      CSP_HTML("script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'") +
+      '<div style="display:none"></div>';
+    const out = injectCspHashes(html);
+    expect(out).to.contain("style-src 'self' 'unsafe-inline'");
+    expect(out).to.not.contain("script-src 'self' 'unsafe-inline'");
+  });
+
+  it("drops 'unsafe-inline' from style-src when the only inline styling is a <style> block", () => {
+    const html = CSP_HTML("style-src 'self' 'unsafe-inline'") + "<style>.a{}</style>";
+    const out = injectCspHashes(html);
+    expect(out).to.not.contain("'unsafe-inline'");
+  });
+
+  it("preserves the semicolon-separated directive formatting", () => {
+    const html = CSP_HTML("default-src 'self'; script-src 'self' 'unsafe-inline'") + "<script>x()</script>";
+    const out = injectCspHashes(html);
+    const content = /content="([^"]*)"/.exec(out)[1];
+    expect(content.split(";").map((d) => d.trim())).to.deep.equal([
+      "default-src 'self'",
+      `script-src 'self' ${sriHash("x()")}`
+    ]);
+  });
+});

--- a/tests/unit/filters.test.mjs
+++ b/tests/unit/filters.test.mjs
@@ -117,4 +117,18 @@ describe("filters — renderMarkdown", () => {
   it("exposes the same instance Eleventy uses for .md files", () => {
     expect(markdownLibrary).to.have.property("render").that.is.a("function");
   });
+
+  it("renders aligned table columns as classes, not inline style attributes", () => {
+    const out = renderMarkdown("| L | R | C |\n|:---|---:|:---:|\n| a | b | c |\n");
+    expect(out).to.contain('class="ta-left"');
+    expect(out).to.contain('class="ta-right"');
+    expect(out).to.contain('class="ta-center"');
+    expect(out).to.not.contain("style=");
+  });
+
+  it("leaves unaligned table columns without a class", () => {
+    const out = renderMarkdown("| A |\n|---|\n| a |\n");
+    expect(out).to.not.contain("class=");
+    expect(out).to.not.contain("style=");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `lib/csp-hash.mjs` and an Eleventy transform that rewrites each page's CSP `<meta>` tag: `'unsafe-inline'` on `script-src`/`style-src` is replaced with sha256 hashes of that page's own rendered inline `<script>`/`<style>` blocks.
- Working from the final rendered HTML (not the source templates) is what makes this correct per-page — the embedded Gig Tracker's `<script>` and the `appInlineStyles` `<style>` block both vary by page.
- `script-src` is now `'unsafe-inline'`-free on every page.
- `style-src` keeps `'unsafe-inline'` on the Gig Tracker page only: it embeds a third-party app that sets `style="..."` attributes with values computed at runtime (chart colours, crosshair lines), and CSP hash sources can't cover an attribute whose value isn't known ahead of time. This is detected per page from the rendered HTML rather than hardcoded to a route, so any future page in the same situation gets the same treatment automatically.
- Two inline `style="..."` attributes that were in the site's own templates move out, so they don't force `'unsafe-inline'` onto every page:
  - the Mailchimp honeypot field → a `.subscribe-honeypot` class
  - a stray `style="border: 0;"` on a setlist.fm embed image → dropped (no-op on an `<img>` not inside a link)
- markdown-it's table-alignment inline style (`style="text-align:…"`) is now rewritten to a `ta-left`/`ta-right`/`ta-center` class via a markdown-it core rule, so a future post with an aligned table doesn't reintroduce the need for `'unsafe-inline'`.

Closes #100.

## Test plan

- [x] `npm run test:unit` — 100% coverage maintained on `lib/`
- [x] `npm run test:smoke`
- [x] `npm run test:theme`
- [x] `npm run test:analytics`
- [x] `npm run test:gigtracker`
- [x] `npm run test:app-nav`
- [x] `npm run test:visual` — no baseline diffs
- [x] `npm run lint:html`
- [x] Verified with Playwright against the built `_site/`: no CSP console violations on the home page, 404, ExifCmdLine, a post with a markdown table, a gig post, and the Gig Tracker (including opening its Statistics panel, which sets the runtime `style="background:…"` attributes)