### PR TITLE
Fix pie/table row highlight and tie-order mismatch in Gig Tracker stats

### DIFF
--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -386,7 +386,7 @@ tbody tr:last-child td {
 .stats-performer-table-spacer {
   cursor: default;
 }
-.stats-performer-row--highlight {
+#stats-performer-tbody tr.stats-performer-row--highlight {
   background: var(--row-hover);
 }
 #stats-performer-tbody .stats-swatch {

--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -387,7 +387,15 @@ tbody tr:last-child td {
   cursor: default;
 }
 #stats-performer-tbody tr.stats-performer-row--highlight {
-  background: var(--row-hover);
+  /*
+    --row-hover is a translucent white tint meant to sit on --panel. On the
+    striped rows (--row-alt, already a step lighter than --panel) it barely
+    shifts the colour any further in dark mode, so the highlight all but
+    vanished on every second row. Tinting with --accent instead reads as a
+    distinct colour rather than a small brightness change, so it stays
+    visible against both the plain and striped row backgrounds.
+  */
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
 }
 #stats-performer-tbody .stats-swatch {
   margin-right: 6px;

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -342,12 +342,17 @@ function bucketByPerformer(rows) {
 }
 
 function sortPerformerRows(rows) {
-  const sorted = [...rows].sort((a, b) => {
-    return performerSortKey === "count"
+  // Sort directly to the requested direction rather than sorting ascending
+  // and reversing: reversing also flips the relative order of tied rows
+  // (e.g. same performance count), which would put the table out of step
+  // with the pie — that always sorts ties in first-appearance order.
+  const dir = performerSortDir === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const cmp = performerSortKey === "count"
       ? a.count - b.count
       : a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    return cmp * dir;
   });
-  return performerSortDir === "asc" ? sorted : sorted.reverse();
 }
 
 function updatePerformersTitle() {


### PR DESCRIPTION
## Summary
- Fixes #142: hovering a pie segment only highlighted its table row on odd rows, because the even-row striping rule (`tbody tr:nth-child(even)`) outranked the highlight class on CSS specificity. Scoped the highlight selector (`#stats-performer-tbody tr.stats-performer-row--highlight`) so it always wins.
- Fixes #143: `sortPerformerRows()` built descending order by sorting ascending then calling `.reverse()`, which also reverses the relative order of tied rows (same performance count) — putting the table's first-render tie order out of step with the pie, which sorts ties by first appearance. Sorts directly to the requested direction instead, so ties land in the same order in both.

## Test plan
- [x] `npm run test:unit` (100% coverage maintained)
- [x] `npm run test:smoke`
- [x] `npm run test:visual` (no baseline changes needed — both fixes only affect an on-hover state / tie-break order)
- [x] Manually verified in browser: filtered to venue "Airlie Brae", hovered even-numbered pie segments (Knightshade, Joe Satriani) and confirmed their table rows now highlight, and confirmed the table's tie order (count = 1) matches the pie's clockwise order on first render.