### PR TITLE
Enable mouse wheel zoom on the gig tracker statistics map

### DIFF
--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -672,7 +672,7 @@ function renderStatsMap(rows) {
   wrap.hidden = false;
 
   if (!statsMap) {
-    statsMap = L.map("stats-map", { attributionControl: true, scrollWheelZoom: false });
+    statsMap = L.map("stats-map", { attributionControl: true, scrollWheelZoom: true });
     L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
       attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
       maxZoom: 18

--- a/tests/gig-tracker-stats-map.test.mjs
+++ b/tests/gig-tracker-stats-map.test.mjs
@@ -129,6 +129,33 @@ describe('Gig Tracker statistics map view', function () {
     await context.close();
   });
 
+  it('zooms in on mouse wheel (#146)', async function () {
+    const { context, page } = await openPage();
+    await page.selectOption('#f-city', 'Wellington');
+    await page.waitForSelector('#stats-map-wrap:not([hidden])');
+    await page.waitForSelector('.gig-map-marker');
+
+    // Tile URLs carry the current zoom as their {z} segment, so a rising z
+    // in later tile requests is proof the wheel actually zoomed the map
+    // (scrollWheelZoom: false would leave every request at the initial z).
+    const requestedZooms = [];
+    page.on('request', (req) => {
+      const match = req.url().match(/tile\.openstreetmap\.org\/(\d+)\//);
+      if (match) requestedZooms.push(Number(match[1]));
+    });
+
+    const initialZoom = Math.max(...requestedZooms);
+    const mapBox = await page.locator('#stats-map').boundingBox();
+    await page.mouse.move(mapBox.x + mapBox.width / 2, mapBox.y + mapBox.height / 2);
+    await page.mouse.wheel(0, -200);
+    // Leaflet debounces wheel input before applying a zoom step, then fetches
+    // the new tiles.
+    await page.waitForTimeout(500);
+    expect(Math.max(...requestedZooms), 'expected a tile request at a higher zoom level after wheel scroll')
+      .to.be.greaterThan(initialZoom);
+    await context.close();
+  });
+
   it('hides again when filters are cleared', async function () {
     const { context, page } = await openPage();
     await page.selectOption('#f-city', 'Wellington');


### PR DESCRIPTION
## Summary

- Flips `scrollWheelZoom` from `false` to `true` on the Leaflet map in the Statistics panel — touch pinch/spread already zoomed fine, but desktop mouse wheel did nothing. Closes #146.
- Adds a Playwright test that scrolls the wheel over the map and confirms Leaflet requests tiles at a higher zoom level afterward.

## Test plan

- [x] `npm run test:unit` — coverage stays at 100%
- [x] `npm run test:smoke`
- [x] `npm run test:gigtracker-stats-map` — new wheel-zoom test passes alongside the existing map suite