### PR TITLE
Keep gig tracker statistics map always visible, synced marker levels

### DIFF
--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -5,6 +5,7 @@
   --text: #e8e9ec;
   --muted: #9aa0ac;
   --accent: #7c9eff;
+  --accent-venue: #e8a33d;
   --row-alt: #14171d;
   --row-hover: #1e222c;
   --cat-music: #5b8def;
@@ -256,6 +257,9 @@ tbody tr:last-child td {
   font-size: 0.75rem;
   font-weight: 700;
   border: 2px solid var(--panel);
+}
+.gig-map-marker--venue {
+  background: var(--accent-venue);
 }
 .stats-chart-wrap {
   position: relative;

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -645,13 +645,14 @@ let statsMapMarkers = null;
  * with no resolved location (see gigTrackerApp.mjs's build-time warning) are
  * silently excluded — there is nowhere on the map to put them.
  *
- * With a City filter active, markers sit at venue precision (row.lat/lng).
- * With only Country active, every gig collapses onto its city's pin
- * (row.cityLat/cityLng) instead — two gigs at different venues in the same
- * city should read as one marker showing "2", not two separate pins.
+ * With a City or Venue filter active, markers sit at venue precision
+ * (row.lat/lng) and render in the venue accent colour. Otherwise every gig
+ * collapses onto its city's pin (row.cityLat/cityLng) in the default accent
+ * colour — two gigs at different venues in the same city should read as one
+ * marker showing "2", not two separate pins.
  */
 function renderStatsMap(rows) {
-  const cityLevel = !filters.city;
+  const cityLevel = !filters.city && !filters.venue;
   const byLocation = new Map();
   for (const row of rows) {
     const lat = cityLevel ? row.cityLat : row.lat;
@@ -701,7 +702,7 @@ function renderStatsMap(rows) {
       className: "gig-map-marker-wrap",
       // title gives a native hover tooltip and a hook for tests — Leaflet's
       // own bindTooltip below isn't in the DOM until actually shown.
-      html: `<span class="gig-map-marker" title="${escapeAttr(label)}">${location.gigs.length}</span>`,
+      html: `<span class="gig-map-marker${cityLevel ? "" : " gig-map-marker--venue"}" title="${escapeAttr(label)}">${location.gigs.length}</span>`,
       iconSize: [28, 28]
     });
     L.marker([location.lat, location.lng], { icon })
@@ -715,11 +716,7 @@ function renderStats(filteredRows) {
   const rows = filteredRows || applyFilters(GIGS);
   updateStatsTitle();
   renderStatsLegend();
-  if (filters.country || filters.city) {
-    renderStatsMap(rows);
-  } else {
-    document.getElementById("stats-map-wrap").hidden = true;
-  }
+  renderStatsMap(rows);
   const wrap = document.getElementById("stats-chart-wrap");
   wrap.classList.add("stats-chart-wrap--updating");
   drawStatsChart(bucketByMonth(rows));

--- a/tests/gig-tracker-stats-map.test.mjs
+++ b/tests/gig-tracker-stats-map.test.mjs
@@ -1,7 +1,8 @@
 /**
- * Behavioural tests for the Gig Tracker statistics map view (#139): it only
- * appears once a Country or City filter is active, and shows one marker per
- * resolved location with the gig count on it.
+ * Behavioural tests for the Gig Tracker statistics map view (#139): it is
+ * always visible (#149) and shows one marker per resolved location with the
+ * gig count on it, switching between city-level and venue-level pins (#148)
+ * depending on which filters are active.
  *
  * OpenStreetMap tile requests are intercepted rather than hitting the real
  * network — the first thing in this suite to make an external HTTP call, so
@@ -49,16 +50,19 @@ describe('Gig Tracker statistics map view', function () {
     return { context, page };
   }
 
-  it('stays hidden with no country or city filter active', async function () {
+  it('stays visible at city level with no country, city, or venue filter active', async function () {
     const { context, page } = await openPage();
     await page.selectOption('#f-performer', { index: 1 });
     await page.waitForTimeout(100);
     const hidden = await page.getAttribute('#stats-map-wrap', 'hidden');
-    expect(hidden).to.not.equal(null);
+    expect(hidden).to.equal(null);
+    await page.waitForSelector('.gig-map-marker');
+    const venueMarkers = await page.$$('.gig-map-marker--venue');
+    expect(venueMarkers.length, 'expected only city-level markers').to.equal(0);
     await context.close();
   });
 
-  it('shows a marker per venue when filtered by city', async function () {
+  it('shows a venue-coloured marker per venue when filtered by city', async function () {
     const { context, page } = await openPage();
     await page.selectOption('#f-city', 'Wellington');
     await page.waitForSelector('#stats-map-wrap:not([hidden])');
@@ -75,6 +79,17 @@ describe('Gig Tracker statistics map view', function () {
     // Every Wellington gig has a resolvable location, so marker counts should
     // sum to the full filtered row count.
     expect(total).to.equal(rowCount);
+
+    const nonVenueMarkers = await page.$$('.gig-map-marker:not(.gig-map-marker--venue)');
+    expect(nonVenueMarkers.length, 'expected every marker to be venue-level when filtered by city').to.equal(0);
+    await context.close();
+  });
+
+  it('shows venue-level pins when filtered by venue, even without a city or country filter', async function () {
+    const { context, page } = await openPage();
+    await page.selectOption('#f-venue', { index: 1 });
+    await page.waitForSelector('#stats-map-wrap:not([hidden])');
+    await page.waitForSelector('.gig-map-marker--venue');
     await context.close();
   });
 
@@ -86,6 +101,9 @@ describe('Gig Tracker statistics map view', function () {
 
     const markerCounts = await page.$$eval('.gig-map-marker', (els) => els.map((el) => Number(el.textContent)));
     expect(markerCounts.length).to.be.greaterThan(1); // several UK cities in the data
+
+    const venueMarkers = await page.$$('.gig-map-marker--venue');
+    expect(venueMarkers.length, 'expected city-level markers with only a country filter').to.equal(0);
     await context.close();
   });
 
@@ -156,14 +174,15 @@ describe('Gig Tracker statistics map view', function () {
     await context.close();
   });
 
-  it('hides again when filters are cleared', async function () {
+  it('falls back to city-level pins when filters are cleared', async function () {
     const { context, page } = await openPage();
     await page.selectOption('#f-city', 'Wellington');
-    await page.waitForSelector('#stats-map-wrap:not([hidden])');
+    await page.waitForSelector('.gig-map-marker--venue');
     await page.click('#reset');
-    // The element still exists (Playwright's default "visible" wait state
-    // wouldn't match it once display:none via [hidden] takes effect).
-    await page.waitForSelector('#stats-map-wrap[hidden]', { state: 'attached' });
+    await page.waitForSelector('#stats-map-wrap:not([hidden])');
+    await page.waitForSelector('.gig-map-marker');
+    const venueMarkers = await page.$$('.gig-map-marker--venue');
+    expect(venueMarkers.length, 'expected city-level markers after reset').to.equal(0);
     await context.close();
   });
 });


### PR DESCRIPTION
## Summary
- Removes the country/city gate around the statistics map so it's always shown, matching the panel's existing height budget.
- Syncs marker aggregation level with the active filters: venue-precision markers (distinct colour) when a city or venue filter is active, city-level otherwise.

Closes #149.
Closes #148.

## Test plan
- [x] `npm run test:unit` — 149 passing, coverage 100%
- [x] `npm run build`
- [x] `npx mocha tests/gig-tracker-stats-map.test.mjs tests/gig-tracker-stats-toggle.test.mjs tests/gig-tracker-filter-adaptation.test.mjs tests/gig-tracker-stats-chart.test.mjs tests/gig-tracker.test.mjs` — 29 passing
- [x] `npm run test:smoke` — 49 passing