### PR TITLE
Make city-level statistics map markers set the city filter

### DIFF
--- a/content/GigTracker/gig-history.css
+++ b/content/GigTracker/gig-history.css
@@ -261,6 +261,31 @@ tbody tr:last-child td {
 .gig-map-marker--venue {
   background: var(--accent-venue);
 }
+.gig-map-marker:not(.gig-map-marker--venue) {
+  cursor: pointer;
+}
+.stats-map .leaflet-tooltip {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  color: var(--text);
+  box-shadow: none;
+}
+.gig-map-city-label {
+  color: var(--accent);
+  border-bottom: 1px dotted var(--accent);
+}
+.stats-map .leaflet-tooltip-top::before {
+  border-top-color: var(--panel);
+}
+.stats-map .leaflet-tooltip-bottom::before {
+  border-bottom-color: var(--panel);
+}
+.stats-map .leaflet-tooltip-left::before {
+  border-left-color: var(--panel);
+}
+.stats-map .leaflet-tooltip-right::before {
+  border-right-color: var(--panel);
+}
 .stats-chart-wrap {
   position: relative;
   width: 100%;

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -705,9 +705,19 @@ function renderStatsMap(rows) {
       html: `<span class="gig-map-marker${cityLevel ? "" : " gig-map-marker--venue"}" title="${escapeAttr(label)}">${location.gigs.length}</span>`,
       iconSize: [28, 28]
     });
-    L.marker([location.lat, location.lng], { icon })
-      .bindTooltip(`${label} — ${location.gigs.length} gig${location.gigs.length === 1 ? "" : "s"}`)
+    const gigsLabel = `${location.gigs.length} gig${location.gigs.length === 1 ? "" : "s"}`;
+    // Only city-level markers are clickable — at venue precision the label
+    // is "Venue, City", not a clean "click the city" target. The city name
+    // is styled like a link for the affordance, but the click target is the
+    // marker itself: Leaflet closes the tooltip as soon as the mouse leaves
+    // the marker, which happens before the cursor can reach text inside it.
+    const tooltipContent = cityLevel
+      ? `<span class="gig-map-city-label">${escapeHtml(location.city)}</span> — ${gigsLabel}`
+      : `${label} — ${gigsLabel}`;
+    const marker = L.marker([location.lat, location.lng], { icon })
+      .bindTooltip(tooltipContent)
       .addTo(statsMapMarkers);
+    if (cityLevel) marker.on("click", () => selectFilter("city", location.city));
   }
   statsMap.fitBounds(statsMapMarkers.getBounds(), { padding: [24, 24], maxZoom: 15 });
 }
@@ -883,6 +893,7 @@ function handlePerformerLinkClick(e) {
 
 document.getElementById("tbody").addEventListener("click", handlePerformerLinkClick);
 document.getElementById("stats-performer-tbody").addEventListener("click", handlePerformerLinkClick);
+document.getElementById("stats-map").addEventListener("click", handlePerformerLinkClick);
 
 document.querySelectorAll(".table-scroll thead th").forEach(th => {
   th.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- Clicking a city-level marker on the Gig Tracker statistics map now sets that city as the active filter, matching the existing city links in the history table.
- The city name in the marker tooltip is styled like the table's link (orange, dotted underline), but the actual click target is the marker itself — Leaflet closes the tooltip as soon as the mouse leaves the marker, so a link inside the tooltip content is never mouse-reachable.
- The tooltip box is restyled to the app's dark theme instead of Leaflet's default white box.
- Scoped to city-level markers only; venue-level markers (shown once a city/venue filter narrows the map) are unaffected.

## Test plan
- [x] `npm run test:headless` (build + all 49 smoke tests) passes
- [x] Verified in browser: hover a city marker → styled tooltip shows "City — N gigs"; click the marker → city filter set, table/map/chart re-render filtered
- [x] Confirmed no new unthemed-colour build warnings