### PR TITLE
Show gig counts in Gig Tracker filter dropdowns

### DIFF
--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -168,7 +168,7 @@ function populateFilters() {
     uniqueSorted(key).forEach(({ value, count }) => {
       const opt = document.createElement("option");
       opt.value = value;
-      opt.textContent = `${value}  ${count}`;
+      opt.textContent = count === 1 ? value : `${value} (${count})`;
       sel.appendChild(opt);
     });
     if (filters[key] && Array.from(sel.options).some(o => o.value === filters[key])) {

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -121,23 +121,27 @@ function matchesFilterKey(g, key, value) {
 
 // Options for a dropdown are drawn from rows matching every *other* active
 // filter (search is deliberately excluded, per #118), so activating one
-// filter narrows the rest without ever invalidating itself.
+// filter narrows the rest without ever invalidating itself. Each option also
+// carries a count of the gigs it would show, for the dropdown labels (#153).
 function uniqueSorted(key) {
   let rows = GIGS;
   Object.keys(filters).forEach(otherKey => {
     if (otherKey === key || !filters[otherKey]) return;
     rows = rows.filter(g => matchesFilterKey(g, otherKey, filters[otherKey]));
   });
-  const vals = new Set();
+  const counts = new Map();
+  const bump = v => counts.set(v, (counts.get(v) || 0) + 1);
   if (key === "performer") {
     rows.forEach(g => {
-      splitPerformers(g.performer).forEach(p => vals.add(p));
-      splitPerformers(g.association).forEach(a => vals.add(a));
+      const names = new Set([...splitPerformers(g.performer), ...splitPerformers(g.association)]);
+      names.forEach(bump);
     });
   } else {
-    rows.forEach(g => { if (g[key]) vals.add(g[key]); });
+    rows.forEach(g => { if (g[key]) bump(g[key]); });
   }
-  return Array.from(vals).sort((a,b) => a.localeCompare(b));
+  return Array.from(counts.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, count }));
 }
 
 function attachFilterListeners() {
@@ -161,10 +165,10 @@ function populateFilters() {
   Object.keys(filterIds).forEach(key => {
     const sel = document.getElementById(filterIds[key]);
     while (sel.options.length > 1) sel.remove(1);
-    uniqueSorted(key).forEach(val => {
+    uniqueSorted(key).forEach(({ value, count }) => {
       const opt = document.createElement("option");
-      opt.value = val;
-      opt.textContent = val;
+      opt.value = value;
+      opt.textContent = `${value}  ${count}`;
       sel.appendChild(opt);
     });
     if (filters[key] && Array.from(sel.options).some(o => o.value === filters[key])) {

--- a/tests/gig-tracker-filter-adaptation.test.mjs
+++ b/tests/gig-tracker-filter-adaptation.test.mjs
@@ -46,6 +46,19 @@ describe('Gig Tracker adaptive dropdown filters', function () {
   const optionsOf = (page, selector) =>
     page.$eval(selector, (sel) => Array.from(sel.options).map((o) => o.value).filter(Boolean));
 
+  const optionCountsOf = (page, selector) =>
+    page.$eval(selector, (sel) => Array.from(sel.options)
+      .filter((o) => o.value)
+      .map((o) => {
+        const match = o.textContent.match(/^(.*)  (\d+)$/);
+        return { value: o.value, label: match[1], count: Number(match[2]) };
+      }));
+
+  const shownCount = async (page) => {
+    const text = await page.$eval('#rowcount', (el) => el.textContent);
+    return Number(text.match(/Showing (\d+)/)[1]);
+  };
+
   // Real gig-history data: Australia has gigs in exactly one city (Sydney),
   // which makes it a deterministic fixture for narrowing assertions without
   // needing to hardcode the whole dataset's shape.
@@ -103,5 +116,24 @@ describe('Gig Tracker adaptive dropdown filters', function () {
     await page.fill('#search', SINGLE_CITY_COUNTRY_CITY);
 
     expect(await optionsOf(page, '#f-country')).to.deep.equal(fullCountries);
+  });
+
+  it('labels each dropdown option with the number of gigs it would show (#153)', async function () {
+    const categories = await optionCountsOf(page, '#f-category');
+    expect(categories.length).to.be.greaterThan(0);
+    categories.forEach(({ count }) => expect(count).to.be.greaterThan(0));
+
+    const sample = categories[0];
+    await page.selectOption('#f-category', sample.value);
+    expect(await shownCount(page)).to.equal(sample.count);
+  });
+
+  it('recomputes option counts as other filters narrow the results (#153)', async function () {
+    await page.selectOption('#f-country', SINGLE_CITY_COUNTRY);
+
+    const cityCounts = await optionCountsOf(page, '#f-city');
+    expect(cityCounts).to.have.lengthOf(1);
+    expect(cityCounts[0].value).to.equal(SINGLE_CITY_COUNTRY_CITY);
+    expect(cityCounts[0].count).to.equal(await shownCount(page));
   });
 });

--- a/tests/gig-tracker-filter-adaptation.test.mjs
+++ b/tests/gig-tracker-filter-adaptation.test.mjs
@@ -50,8 +50,10 @@ describe('Gig Tracker adaptive dropdown filters', function () {
     page.$eval(selector, (sel) => Array.from(sel.options)
       .filter((o) => o.value)
       .map((o) => {
-        const match = o.textContent.match(/^(.*)  (\d+)$/);
-        return { value: o.value, label: match[1], count: Number(match[2]) };
+        const match = o.textContent.match(/^(.*) \((\d+)\)$/);
+        return match
+          ? { value: o.value, label: match[1], count: Number(match[2]) }
+          : { value: o.value, label: o.textContent, count: 1 };
       }));
 
   const shownCount = async (page) => {
@@ -135,5 +137,17 @@ describe('Gig Tracker adaptive dropdown filters', function () {
     expect(cityCounts).to.have.lengthOf(1);
     expect(cityCounts[0].value).to.equal(SINGLE_CITY_COUNTRY_CITY);
     expect(cityCounts[0].count).to.equal(await shownCount(page));
+  });
+
+  // Mission Estate Winery has exactly one gig, a deterministic fixture for
+  // asserting the count is omitted rather than showing "(1)".
+  const SINGLE_GIG_VENUE = 'Mission Estate Winery';
+
+  it('omits the count for an option that matches exactly one gig (#153)', async function () {
+    const venueOption = await page.$eval('#f-venue',
+      (sel, value) => Array.from(sel.options).find((o) => o.value === value)?.textContent,
+      SINGLE_GIG_VENUE
+    );
+    expect(venueOption).to.equal(SINGLE_GIG_VENUE);
   });
 });


### PR DESCRIPTION
## Summary
- Each option in the Shows, Categories, Countries, Cities and Venues dropdowns now appends the number of gigs it would show, e.g. "Comedy (26)". An option that matches exactly one gig omits the count entirely (e.g. "Mission Estate Winery" rather than "Mission Estate Winery (1)").
- `uniqueSorted()` now counts occurrences per value (respecting the existing intersection-filtering across the other active dropdowns) and returns `{value, count}` pairs; `populateFilters()` renders the label as `` `${value} (${count})` ``, or bare `value` when the count is 1.

Closes #153.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained
- [x] `npx mocha tests/gig-tracker-filter-adaptation.test.mjs` — added tests: option labels carry correct counts, counts recompute correctly when another filter narrows the dropdown, and a single-gig option omits its count
- [x] Verified manually in the browser — all five dropdowns show correct counts, with single-gig options showing no count
- [x] `npm run test:headless` — full smoke suite passes

Note: `tests/gig-tracker-stats-chart.test.mjs`'s "shows a tooltip and crosshair when hovering a month with gigs" test is flaky on `master` too (confirmed by stashing this change and rerunning) — unrelated to this PR.
