### PR TITLE
Add The Night Before (Great Sounds Great) 2026 gig post

### DIFF
--- a/.claude/skills/new-gig/SKILL.md
+++ b/.claude/skills/new-gig/SKILL.md
@@ -11,13 +11,15 @@ There is a blank template at `content/posts/gigs/template.hmmm` (gitignored, so 
 
 ## 1. Gather
 
-Required:
+Ask one question at a time, waiting for Adrian's answer before asking the next. Don't bundle multiple fields into a single message.
+
+Required, in order:
 
 - **Headline artist**
 - **Venue** and **city** (and **country** — usually `New Zealand`)
 - **Date of the gig** — this is the `date` field and drives the filename
 
-Optional — ask, but don't block on them:
+Optional — ask each one individually, but don't block on them:
 
 - **Support artists** — a list
 - **setlist.fm URL**

--- a/content/posts/gigs/20260904-The-Night-Before-Wellington.md
+++ b/content/posts/gigs/20260904-The-Night-Before-Wellington.md
@@ -1,0 +1,24 @@
+---
+title: 'The Night Before (Great Sounds Great) 2026'
+navtitle: '2026 The Night Before'
+summary: 'Five Wellington acts, two venues, one big night for The Night Before'
+metadesc: 'Concert review of Elly Mae, Dale Kerrigan, Nameless and Brainless, re:ruby and girls factory at Newtown Community Centre & Moon, Wellington, 4 September 2026.'
+date: 2026-09-04
+readingtime: '1 minute'
+headlineArtist: 'Elly Mae, Dale Kerrigan, Nameless and Brainless, re:ruby, girls factory'
+venue: 'Newtown Community Centre & Moon'
+city: 'Wellington'
+country: 'New Zealand'
+---
+Great Sounds Great's "The Night Before" put five Wellington acts across two rooms, Newtown Community Centre and Moon, for one night of new local music.
+<!-- excerpt -->
+
+Elly Mae opened at Newtown Community Centre, a dreamy three-piece somewhere in Hope Sandoval / Mazzy Star territory, sounding assured on stage.
+
+Over at Moon, Nameless and Brainless followed with a tight, competent live band doing rap reminiscent of Avondale or Home Brew Crew. One cheesy hands-in-the-air moment aside, a few more hooks would lift it further.
+
+Back at Newtown Community Centre, Dale Kerrigan were loud but droning, an early Sonic Youth without the direction, Russian Circles without the discipline. Too loose to really land.
+
+re:ruby, at Moon, brought real hooks and melody, early Fur Patrol at first, drifting into something more sombre, Marianne Faithfull by mid-set. Nice compositions, brave enough to go off-piste but tight enough to bring it home again. Pixies-esque at times, maybe a touch of Veruca Salt. Very good, though the transitions between songs could be tighter.
+
+girls factory closed the night at Moon with high energy and a furry dancer in tow, chaotic, wide-ranging, packed the floor and had smiles all over the place.


### PR DESCRIPTION
## Summary
- New gig post for The Night Before (Great Sounds Great), a two-venue Wellington festival on 4 September 2026 with five acts (Elly Mae, Dale Kerrigan, Nameless and Brainless, re:ruby, girls factory) and no single headliner
- Updated the new-gig skill to ask each field one at a time instead of bundling questions

## Test plan
- [x] `npm run build` succeeds
- [x] Confirmed metadata card (date, headline, venue, location) renders on the post page
- [x] Confirmed the post appears on `/gigs/` and the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)