### PR TITLE
Remove unused venue location entry

### DIFF
--- a/content/GigTracker/Locations.md
+++ b/content/GigTracker/Locations.md
@@ -135,7 +135,6 @@ Every Country/City combination also has its own row with a blank Venue, giving t
 | United Kingdom | London | Brixton Academy | 51.46563, -0.11497 |
 | United Kingdom | London | Bush Hall | 51.50652, -0.23161 |
 | United Kingdom | London | Clapham Common | 51.4618, -0.1384 |
-| United Kingdom | London | Coliseum | 51.5100, -0.1281 |
 | United Kingdom | London | Comedy Theatre | 51.5088, -0.1319 |
 | United Kingdom | London | Dominion Theatre | 51.5165, -0.1308 |
 | United Kingdom | London | Earls Court | 51.48889, -0.19778 |


### PR DESCRIPTION
## Summary
- Removed a redundant `London | Coliseum` row from Locations.md — no gig in gig-history.md uses "Coliseum" as a venue name; the correct venue is "London Coliseum", which already has its own row.

## Test plan
- [x] Verified no gig-history.md entries reference venue "Coliseum" (only "London Coliseum")