### PR TITLE
Group co-located venue aliases in Gig Tracker

### DIFF
--- a/content/GigTracker/Locations.md
+++ b/content/GigTracker/Locations.md
@@ -87,7 +87,7 @@ Every Country/City combination also has its own row with a blank Venue, giving t
 | New Zealand | Wellington | Shed 11 | -41.2831, 174.7801 |
 | New Zealand | Wellington | Shed 6 | -41.2825, 174.7807 |
 | New Zealand | Wellington | Show & Sports Centre | |
-| New Zealand | Wellington | Sky Stadium | -41.272861, 174.785202 |
+| New Zealand | Wellington | Sky Stadium | -41.27290, 174.78520 |
 | New Zealand | Wellington | Sol Bar | |
 | New Zealand | Wellington | Soundings Theatre | -41.2906361, 174.781993 |
 | New Zealand | Wellington | St James Theatre | -41.29337, 174.77972 |

--- a/content/GigTracker/Locations.md
+++ b/content/GigTracker/Locations.md
@@ -83,7 +83,7 @@ Every Country/City combination also has its own row with a blank Venue, giving t
 | New Zealand | Wellington | Paramount Theatre | -41.2932, 174.7775 |
 | New Zealand | Wellington | Phoenix | |
 | New Zealand | Wellington | Queens Wharf Events Centre | -41.2823, 174.7810 |
-| New Zealand | Wellington | San Fran | -41.2953, 174.7754 |
+| New Zealand | Wellington | San Fran | -41.29415, 174.77556 |
 | New Zealand | Wellington | Shed 11 | -41.2831, 174.7801 |
 | New Zealand | Wellington | Shed 6 | -41.2825, 174.7807 |
 | New Zealand | Wellington | Show & Sports Centre | |

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -112,9 +112,24 @@ function splitPerformers(str) {
   return str.split(",").map(s => s.trim()).filter(Boolean);
 }
 
+// Venues sharing exact coordinates in Locations.md are the same physical
+// place under different names over time (#158) — e.g. "San Fran", "Indigo"
+// and "Stax" are all one Wellington venue. hasVenueLocation gates this so
+// two venues that both merely fell back to their city's pin (no coordinates
+// of their own) aren't mistaken for the same address.
+function venueGroupKey(g) {
+  return g.hasVenueLocation ? `${g.lat},${g.lng}` : `venue:${g.venue}`;
+}
+
+const venueGroupKeyByName = new Map();
+GIGS.forEach(g => { if (g.venue) venueGroupKeyByName.set(g.venue, venueGroupKey(g)); });
+
 function matchesFilterKey(g, key, value) {
   if (key === "performer") {
     return splitPerformers(g.performer).includes(value) || splitPerformers(g.association).includes(value);
+  }
+  if (key === "venue") {
+    return venueGroupKey(g) === venueGroupKeyByName.get(value);
   }
   return g[key] === value;
 }
@@ -123,12 +138,27 @@ function matchesFilterKey(g, key, value) {
 // filter (search is deliberately excluded, per #118), so activating one
 // filter narrows the rest without ever invalidating itself. Each option also
 // carries a count of the gigs it would show, for the dropdown labels (#153).
+// For venue, that count is the combined total across every co-located alias
+// (#158), not just gigs recorded under that one name.
 function uniqueSorted(key) {
   let rows = GIGS;
   Object.keys(filters).forEach(otherKey => {
     if (otherKey === key || !filters[otherKey]) return;
     rows = rows.filter(g => matchesFilterKey(g, otherKey, filters[otherKey]));
   });
+  if (key === "venue") {
+    const groupCounts = new Map();
+    const groupKeyByName = new Map();
+    rows.forEach(g => {
+      if (!g.venue) return;
+      const gk = venueGroupKey(g);
+      groupCounts.set(gk, (groupCounts.get(gk) || 0) + 1);
+      groupKeyByName.set(g.venue, gk);
+    });
+    return Array.from(groupKeyByName.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([value, gk]) => ({ value, count: groupCounts.get(gk) }));
+  }
   const counts = new Map();
   const bump = v => counts.set(v, (counts.get(v) || 0) + 1);
   if (key === "performer") {
@@ -700,7 +730,18 @@ function renderStatsMap(rows) {
     if (hasFallback) {
       label = `Unknown address, ${location.city}`;
     } else if (!cityLevel && location.venue) {
-      label = `${location.venue}, ${location.city}`;
+      // Co-located venues (#158) — several names sharing this address over
+      // time — get a breakdown instead of one arbitrary name.
+      const nameCounts = new Map();
+      location.gigs.forEach(g => {
+        if (g.venue) nameCounts.set(g.venue, (nameCounts.get(g.venue) || 0) + 1);
+      });
+      label = nameCounts.size > 1
+        ? Array.from(nameCounts.entries())
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([name, count]) => `${name} (${count})`)
+            .join(", ")
+        : `${location.venue}, ${location.city}`;
     }
     const icon = L.divIcon({
       className: "gig-map-marker-wrap",

--- a/tests/gig-tracker-filter-adaptation.test.mjs
+++ b/tests/gig-tracker-filter-adaptation.test.mjs
@@ -150,4 +150,32 @@ describe('Gig Tracker adaptive dropdown filters', function () {
     );
     expect(venueOption).to.equal(SINGLE_GIG_VENUE);
   });
+
+  // "San Fran", "Indigo" and "Stax" are all the same Wellington venue at
+  // different points in its history — Locations.md gives them identical
+  // coordinates, which is how the app decides they're co-located (#158).
+  const CO_LOCATED_VENUES = ['San Fran', 'Indigo', 'Stax'];
+
+  it('gives every co-located venue alias the same combined count (#158)', async function () {
+    const venueCounts = await optionCountsOf(page, '#f-venue');
+    const counts = CO_LOCATED_VENUES.map((name) =>
+      venueCounts.find((v) => v.value === name)?.count
+    );
+    expect(counts.every((c) => typeof c === 'number')).to.be.true;
+    expect(new Set(counts).size).to.equal(1);
+
+    const combinedTotal = counts[0];
+    await page.selectOption('#f-venue', CO_LOCATED_VENUES[0]);
+    expect(await shownCount(page)).to.equal(combinedTotal);
+  });
+
+  it('filters to gigs from every co-located venue alias, not just the selected one (#158)', async function () {
+    await page.selectOption('#f-venue', 'Indigo');
+
+    const rowVenues = await page.$$eval('#tbody tr', (rows) =>
+      rows.map((r) => r.children[5].textContent.trim())
+    );
+    CO_LOCATED_VENUES.forEach((name) => expect(rowVenues).to.include(name));
+    rowVenues.forEach((v) => expect(CO_LOCATED_VENUES).to.include(v));
+  });
 });

--- a/tests/gig-tracker-stats-map.test.mjs
+++ b/tests/gig-tracker-stats-map.test.mjs
@@ -204,6 +204,27 @@ describe('Gig Tracker statistics map view', function () {
     await context.close();
   });
 
+  it('collapses co-located venue aliases onto one marker with a per-alias breakdown (#158)', async function () {
+    // San Fran, Indigo and Stax are the same Wellington address under
+    // different names over time (Locations.md gives them identical
+    // coordinates) — they should read as one marker, not three.
+    const { context, page } = await openPage();
+    await page.selectOption('#f-city', 'Wellington');
+    await page.waitForSelector('#stats-map-wrap:not([hidden])');
+    await page.waitForSelector('.gig-map-marker');
+
+    const markers = await page.$$('.gig-map-marker[title*="San Fran"]');
+    expect(markers.length, 'expected San Fran, Indigo and Stax to share a single marker').to.equal(1);
+
+    const [marker] = markers;
+    const title = await marker.getAttribute('title');
+    expect(title).to.include('San Fran (12)');
+    expect(title).to.include('Indigo (8)');
+    expect(title).to.include('Stax (2)');
+    expect(Number(await marker.textContent()), 'expected the badge to show the combined total').to.equal(22);
+    await context.close();
+  });
+
   it('falls back to city-level pins when filters are cleared', async function () {
     const { context, page } = await openPage();
     await page.selectOption('#f-city', 'Wellington');


### PR DESCRIPTION
## Summary
- Fixes San Fran's coordinates in `Locations.md` to match Indigo/Stax — they're the same Wellington venue at different points in its history, and the app decides co-location by matching lat/lng.
- Venue dropdown option counts are now the combined total across all aliases sharing a venue's coordinates, not just gigs recorded under that exact name.
- Selecting any one alias in the venue filter now shows gigs from every alias at that address.
- The Statistics map already collapsed co-located venues onto one marker (once coordinates match) — its tooltip now breaks the combined count down per alias (e.g. "San Fran (12), Indigo (8), Stax (2)") instead of showing one arbitrary name.
- Also removes a redundant duplicate Locations.md row for the London Coliseum (was already on this branch).

Closes #158.

## Test plan
- [x] `npm run test:unit` — 100% coverage maintained, unaffected (no `lib/` changes)
- [x] `npm run test:smoke` — all passing
- [x] `npx mocha tests/gig-tracker-filter-adaptation.test.mjs tests/gig-tracker-stats-map.test.mjs` — all passing, including 3 new cases covering combined counts, cross-alias filtering, and the marker tooltip breakdown