### PR TITLE
Fix Flickr CSP and Gig Tracker comma-splitting bug

### DIFF
--- a/content/GigTracker/README.md
+++ b/content/GigTracker/README.md
@@ -37,7 +37,15 @@ followed by one data row per gig, most recent first:
 
 All nine columns are required on every row (leave a column blank rather than
 omitting it — see the `Notes`, `Association` and `Setlist.fm ID` columns
-above). Free text before the header (a title, a description paragraph) and
+above).
+
+`Show` and `Association` are comma-separated lists of artist names, split on
+the client side (`splitPerformers` in `gig-history.html`). An artist name that
+contains a literal comma (e.g. "Does It Offend You, Yeah?") must have that
+comma escaped as `\,` so it isn't mistaken for the list separator — see the
+2010-11-11 and 2010-07-24 rows for examples.
+
+Free text before the header (a title, a description paragraph) and
 after the table (notes) is ignored by the parser in `lib/gig-history.mjs`;
 only lines starting with `|` after the header count as rows. A row with the
 wrong number of columns — too few or too many — fails the build rather than

--- a/content/GigTracker/gig-history.html
+++ b/content/GigTracker/gig-history.html
@@ -107,9 +107,13 @@ const filterIds = {
   venue: "f-venue"
 };
 
+// A performer/association list is comma-separated, but a handful of artist
+// names contain a literal comma themselves (e.g. "Does It Offend You, Yeah?")
+// — those are written in gig-history.md with the comma escaped as "\," so it
+// survives the list split intact, then unescaped back to a plain comma here.
 function splitPerformers(str) {
   if (!str) return [];
-  return str.split(",").map(s => s.trim()).filter(Boolean);
+  return str.split(/(?<!\\),/).map(s => s.trim().replace(/\\,/g, ",")).filter(Boolean);
 }
 
 // Venues sharing exact coordinates in Locations.md are the same physical

--- a/content/GigTracker/gig-history.md
+++ b/content/GigTracker/gig-history.md
@@ -224,13 +224,13 @@ Data has been manually improved, validated and some gigs identified in gigs-miss
 | 2010-11-21 | Soulfly | Music | London | United Kingdom | KOKO | | | Soulfly:6bd2be62 |
 | 2010-11-19 | Therapy? | Music | London | United Kingdom | The Forum | | | |
 | 2010-11-17 | Deftones, Coheed and Cambria | Music | London | United Kingdom | Brixton Academy | | | Deftones:43d547ab, Coheed and Cambria:bd541e2 |
-| 2010-11-11 | Linkin Park, Does It Offend You, Yeah? | Music | London | United Kingdom | The O2 Arena | | | Linkin Park:33de606d, Does It Offend You, Yeah?:53da1761 |
+| 2010-11-11 | Linkin Park, Does It Offend You\, Yeah? | Music | London | United Kingdom | The O2 Arena | | | Linkin Park:33de606d, Does It Offend You, Yeah?:53da1761 |
 | 2010-10-23 | Morcheeba | Music | London | United Kingdom | Roundhouse | | | Morcheeba:4bd5073e |
 | 2010-10-20 | Stephen Hawking | Other | London | United Kingdom | Royal Albert Hall | The Grand Design | | |
 | 2010-10-13 | Guns N' Roses, Sebastian Bach | Music | London | United Kingdom | The O2 Arena | | | Guns N' Roses:7bd51e34 |
 | 2010-09-25 | Zodiac Mindwarp & The Love Reaction | Music | London | United Kingdom | Borderline | | | Zodiac Mindwarp & The Love Reaction:2bffac06 |
 | 2010-08-19 | La Bete | Theatre | London | United Kingdom | Comedy Theatre | Starring Mark Rylance, David Hyde Pierce, Joanna Lumley, Stephen Ouimette. Directed by Matthew Warchus | | |
-| 2010-07-24 | The Prodigy, Pendulum, Chase & Status, Enter Shikari, Does It Offend You, Yeah?, Zane Lowe | Music | Milton Keynes | United Kingdom | Milton Keynes Bowl | Warriors Dance Festival | | The Prodigy:63d45a9f, Pendulum:4bd457be, Chase & Status:3bd454c0, Enter Shikari:1bd455a4, Does It Offend You, Yeah?:1bd2ed18 |
+| 2010-07-24 | The Prodigy, Pendulum, Chase & Status, Enter Shikari, Does It Offend You\, Yeah?, Zane Lowe | Music | Milton Keynes | United Kingdom | Milton Keynes Bowl | Warriors Dance Festival | | The Prodigy:63d45a9f, Pendulum:4bd457be, Chase & Status:3bd454c0, Enter Shikari:1bd455a4, Does It Offend You, Yeah?:1bd2ed18 |
 | 2010-07-22 | Sepultura, Gama Bomb | Music | London | United Kingdom | Scala | | | Sepultura:bd45966, Gama Bomb:33964c1d |
 | 2010-07-17 | Penn & Teller | Comedy | London | United Kingdom | Hammersmith Apollo | | | |
 | 2010-07-14 | Gil Scott-Heron | Music | London | United Kingdom | Somerset House | | | Gil Scott-Heron:33d46c1d |


### PR DESCRIPTION
## Summary
- Allow `embedr.flickr.com` in the CSP `connect-src` directive so Flickr slideshow embeds on gig posts work.
- Fix the Gig Tracker app splitting artist names containing a literal comma (e.g. "Does It Offend You, Yeah?") into two separate performers in filters/search/stats. `splitPerformers()` in `gig-history.html` now supports an escaped comma (`\,`) that survives the list split; the two affected rows in `gig-history.md` are updated accordingly, and the escaping convention is documented in the Gig Tracker README.

## Test plan
- [x] `npm run test:unit` — 149 passing, 100% coverage
- [x] `npm run test:smoke` — 49 passing